### PR TITLE
fix ('build-cron/update-dependencies' job): call 'git push', not 'git ps'

### DIFF
--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -61,7 +61,7 @@ jobs:
         done
     - id: push-updates
       shell: bash
-      run: git ps -u origin ${{ steps.create-branch.branch }}
+      run: git push -u origin ${{ steps.create-branch.branch }}
     - id: create-pr
       shell: bash
       env:


### PR DESCRIPTION
reason: the latter is an alias used on the dev machine
