### PR TITLE
refactor: fix assembly packing for upm pack

### DIFF
--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -61,7 +61,7 @@ public partial class Context
             var executingAssembly = Assembly.GetEntryAssembly();
             var assemblyName = executingAssembly.GetName();
 
-            framework = packageReader.GetPreferredFramework(
+            framework = packageReader.SelectPreferredFramework(
                 framework != null ? new[] { framework } : DefaultFrameworks
             );
 

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -65,6 +65,7 @@ public partial class Context
             var selectedFramework = packageReader.SelectPreferredFramework(
                 framework != null ? new[] { framework } : DefaultFrameworks
             );
+            Console.WriteLine($"selected framework: {selectedFramework}");
 
             var files = packageReader.GetFrameworkFiles(selectedFramework);
 

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -33,6 +33,7 @@ public partial class Context
         "netstandard1.2",
         "netstandard1.1",
         "netstandard1.0",
+        "net462",
     };
 
     public async Task<Tuple<string, FileDictionary>?> PackUpmPackage(

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -62,11 +62,11 @@ public partial class Context
             var executingAssembly = Assembly.GetEntryAssembly();
             var assemblyName = executingAssembly.GetName();
 
-            framework = packageReader.SelectPreferredFramework(
+            var selectedFramework = packageReader.SelectPreferredFramework(
                 framework != null ? new[] { framework } : DefaultFrameworks
             );
 
-            var files = packageReader.GetFrameworkFiles(framework);
+            var files = packageReader.GetFrameworkFiles(selectedFramework);
 
             // create & add README
             var readme = nuspecReader.GenerateUpmReadme(assemblyName);
@@ -85,7 +85,7 @@ public partial class Context
 
             // create package.json
             var packageJson = nuspecReader.GenerateUpmPackageJson(
-                framework: framework,
+                framework: selectedFramework,
                 targetRegistry: target,
                 assemblyName: assemblyName
             );

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -17,9 +17,10 @@ public static class PackageArchiveReaderExtension
     {
         return packageReader
             .GetFiles("lib")
-            .Select(f => f.Replace("lib/", string.Empty))
-            .Select(f => Path.GetPathRoot(f))
-            .Distinct();
+            .Select(f => Path.GetDirectoryName(f))
+            .Select(f => f?.Replace("lib/", string.Empty))
+            .Distinct()
+            .OrderDescending();
     }
 
     public static string? GetPreferredFramework(

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -23,12 +23,13 @@ public static class PackageArchiveReaderExtension
             .OrderDescending();
     }
 
-    public static string GetPreferredFramework(
+    public static string SelectPreferredFramework(
         this PackageArchiveReader packageReader,
         IEnumerable<string> frameworks
     )
     {
         var assemblyFrameworks = packageReader.GetAssemblyFrameworks();
+        Console.WriteLine($"assemblyFrameworks: {string.Join(", ", assemblyFrameworks)}");
 
         foreach (var framework in frameworks)
         {

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -48,8 +48,8 @@ public static class PackageArchiveReaderExtension
         return new TarGz.FileDictionary(
             packageReader
                 .GetFiles("lib")
-                .Where(f => Path.GetDirectoryName(f) == Path.Join("lib", framework))
-                .ToDictionary(f => Path.GetFileName(f), f => packageReader.GetBytes(f))
+                .Where(f => f.Contains(framework))
+                .ToDictionary(f => f, f => packageReader.GetBytes(f))
         );
     }
 }

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -23,7 +23,7 @@ public static class PackageArchiveReaderExtension
             .OrderDescending();
     }
 
-    public static string? GetPreferredFramework(
+    public static string GetPreferredFramework(
         this PackageArchiveReader packageReader,
         IEnumerable<string> frameworks
     )
@@ -36,7 +36,7 @@ public static class PackageArchiveReaderExtension
                 return framework;
         }
 
-        return null;
+        return string.Empty;
     }
 
     public static TarGz.FileDictionary GetFrameworkFiles(

--- a/NuGettier.Upm/TarGz/FileDictionaryMetaExtension.cs
+++ b/NuGettier.Upm/TarGz/FileDictionaryMetaExtension.cs
@@ -8,9 +8,26 @@ public static class FileDictionaryMetaExtension
 {
     public static void AddMetaFiles(this FileDictionary fileDictionary, string seed)
     {
+        var files = fileDictionary.Keys.ToList(); //< make a temp copy to avoid modifying the collection
+
+        // gather folders: Unity requires .meta files for each included folder as well
+        var folders = files
+            .SelectMany(f =>
+            {
+                var parents = new List<string>();
+                var p = Path.GetDirectoryName(f);
+                while (!string.IsNullOrEmpty(p))
+                {
+                    parents.Add(p);
+                    p = Path.GetDirectoryName(p);
+                }
+                return parents;
+            })
+            .Distinct();
+
         fileDictionary.AddRange(
-            fileDictionary.Keys
-                .ToList() //< make a temp copy to avoid modifying the collection
+            files
+                .Concat(folders) //< files AND folders
                 .Where(file => Path.GetExtension(file) != @".meta")
                 .Select(
                     file =>


### PR DESCRIPTION
- fix (NuGettier.Upm): fix PackageArchiveReader.GetAssemblyFrameworks extension method to return list of contained assemblies
- fix (NuGettier.Upm): return string.Empty instead of null from PackageArchiveReaderExtension.GetPreferredFramework extension method
- refactor (NuGettier.Upm): rename PackageArchiveReaderExtension extension method GetPreferredFramework -> SelectPreferredFramework
- refactor (NuGettier.Upm): make assembly file selection more error proof
- refactor (NuGettier.Upm): add 'net462' to Default Frameworks
- refactor (NuGettier.Upm): make implementation of PackUpmPackage a bit clearer
- refactor (NuGettier.Upm): print selected framework before packing assemblies
- refactor (NuGettier.Upm): generate meta files for folders
- refactor (NuGettier.Upm): improve meta file generation for folders
