### PR TITLE
refactor (NuGettier.Upm): move implementation for StringStringDictionary into its own file

### DIFF
--- a/NuGettier.Upm/PackageJson/PackageJson.cs
+++ b/NuGettier.Upm/PackageJson/PackageJson.cs
@@ -6,20 +6,6 @@ namespace NuGettier.Upm;
 
 public class PackageJson
 {
-    public sealed class StringStringDictionary : Dictionary<string, string>
-    {
-        public StringStringDictionary()
-            : base() { }
-
-        public StringStringDictionary(StringStringDictionary reference)
-            : this(reference as Dictionary<string, string>) { }
-
-        public StringStringDictionary(Dictionary<string, string> reference)
-            : base(reference) { }
-
-        public StringStringDictionary(IEnumerable<KeyValuePair<string, string>> reference)
-            : base(reference) { }
-    }
 
     public string Name = String.Empty;
     public string name

--- a/NuGettier.Upm/Utility/StringStringDictionary.cs
+++ b/NuGettier.Upm/Utility/StringStringDictionary.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGettier.Upm;
+
+public sealed class StringStringDictionary : Dictionary<string, string>
+{
+    public StringStringDictionary()
+        : base() { }
+
+    public StringStringDictionary(StringStringDictionary reference)
+        : this(reference as Dictionary<string, string>) { }
+
+    public StringStringDictionary(Dictionary<string, string> reference)
+        : base(reference) { }
+
+    public StringStringDictionary(IEnumerable<KeyValuePair<string, string>> reference)
+        : base(reference) { }
+}


### PR DESCRIPTION
reason: re-use by NPM protocol
