### PR TITLE
feature/upm options

### DIFF
--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -42,6 +42,8 @@ public partial class Context
         bool latest,
         string? version,
         string? framework,
+        string? prereleaseSuffix,
+        string? buildmetaSuffix,
         CancellationToken cancellationToken
     )
     {
@@ -71,17 +73,17 @@ public partial class Context
             files.AddRange(packageReader.GetAdditionalFiles(nuspecReader));
 
             // create & add README
-            var readme = nuspecReader.GenerateUpmReadme(assemblyName);
+            var readme = nuspecReader.GenerateUpmReadme(assemblyName, prereleaseSuffix, buildmetaSuffix);
             files.Add("README.md", readme);
             Console.WriteLine($"--- README\n{readme}\n---");
 
             // create & add LICENSE
-            var license = nuspecReader.GenerateUpmLicense();
+            var license = nuspecReader.GenerateUpmLicense(prereleaseSuffix, buildmetaSuffix);
             files.Add("LICENSE.md", license);
             Console.WriteLine($"--- LICENSE\n{license}\n---");
 
             // create & add CHANGELOG
-            var changelog = nuspecReader.GenerateUpmChangelog();
+            var changelog = nuspecReader.GenerateUpmChangelog(prereleaseSuffix, buildmetaSuffix);
             files.Add("CHANGELOG.md", changelog);
             Console.WriteLine($"--- CHANGELOG\n{changelog}\n---");
 
@@ -89,7 +91,9 @@ public partial class Context
             var packageJson = nuspecReader.GenerateUpmPackageJson(
                 framework: selectedFramework,
                 targetRegistry: target,
-                assemblyName: assemblyName
+                assemblyName: assemblyName,
+                prereleaseSuffix: prereleaseSuffix,
+                buildmetaSuffix: buildmetaSuffix
             );
 
             // add file references to package.json

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -100,7 +100,7 @@ public static class NuspecReaderExtension
     {
         return ReadmeStringFactory.GenerateReadme(
             name: $"{nuspecReader.GetUpmName()} ({nuspecReader.GetUpmPackageName()})",
-            version: nuspecReader.GetVersion().ToString(),
+            version: nuspecReader.GetUpmVersion(),
             description: nuspecReader.GetDescription(),
             applicationName: assemblyName.Name,
             applicationVersion: assemblyName.Version.ToString()
@@ -111,7 +111,7 @@ public static class NuspecReaderExtension
     {
         return LicenseStringFactory.GenerateLicense(
             name: nuspecReader.GetUpmName(),
-            version: nuspecReader.GetVersion().ToString(),
+            version: nuspecReader.GetUpmVersion(),
             copyright: nuspecReader.GetCopyright(),
             copyrightHolder: string.IsNullOrEmpty(nuspecReader.GetOwners())
                 ? nuspecReader.GetAuthors()
@@ -125,7 +125,7 @@ public static class NuspecReaderExtension
     {
         return ChangelogStringFactory.GenerateChangelog(
             name: nuspecReader.GetUpmName(),
-            version: nuspecReader.GetVersion().ToString(),
+            version: nuspecReader.GetUpmVersion(),
             releaseNotes: nuspecReader.GetReleaseNotes()
         );
     }
@@ -141,7 +141,7 @@ public static class NuspecReaderExtension
             new()
             {
                 Name = nuspecReader.GetUpmPackageName(),
-                Version = nuspecReader.GetVersion().ToString(),
+                Version = nuspecReader.GetUpmVersion(),
                 License = nuspecReader.GetLicenseMetadata()?.License,
                 Description = nuspecReader.GetDescription(),
                 Keywords = nuspecReader.GetUpmKeywords(),

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -130,11 +130,15 @@ public static class NuspecReaderExtension
         );
     }
 
-    public static string GenerateUpmChangelog(this NuspecReader nuspecReader)
+    public static string GenerateUpmChangelog(
+        this NuspecReader nuspecReader,
+        string? prereleaseSuffix = null,
+        string? buildmetaSuffix = null
+    )
     {
         return ChangelogStringFactory.GenerateChangelog(
             name: nuspecReader.GetUpmName(),
-            version: nuspecReader.GetUpmVersion(),
+            version: nuspecReader.GetUpmVersion(prereleaseSuffix, buildmetaSuffix),
             releaseNotes: nuspecReader.GetReleaseNotes()
         );
     }

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -112,11 +112,15 @@ public static class NuspecReaderExtension
         );
     }
 
-    public static string GenerateUpmLicense(this NuspecReader nuspecReader)
+    public static string GenerateUpmLicense(
+        this NuspecReader nuspecReader,
+        string? prereleaseSuffix = null,
+        string? buildmetaSuffix = null
+    )
     {
         return LicenseStringFactory.GenerateLicense(
             name: nuspecReader.GetUpmName(),
-            version: nuspecReader.GetUpmVersion(),
+            version: nuspecReader.GetUpmVersion(prereleaseSuffix, buildmetaSuffix),
             copyright: nuspecReader.GetCopyright(),
             copyrightHolder: string.IsNullOrEmpty(nuspecReader.GetOwners())
                 ? nuspecReader.GetAuthors()

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -15,13 +15,28 @@ public static class NuspecReaderExtension
 
     public static string GetUpmPackageName(this NuspecReader nuspecReader)
     {
-        // TODO: naming convention => separate function. use also on dependencies
         return GetUpmPackageName(nuspecReader.GetAuthors(), nuspecReader.GetId());
     }
 
     public static string GetUpmPackageName(string author, string id)
     {
+        // TODO: use config string + Handlebars template
         return $"com.{author}.{id}".ToLowerInvariant().Replace(@" ", @"");
+    }
+
+    public static string GetUpmVersion(
+        this NuspecReader nuspecReader,
+        string? prereleaseSuffix = null,
+        string? buildmetaSuffix = null
+    )
+    {
+        var version = nuspecReader.GetVersion().ToString();
+        if (prereleaseSuffix != null)
+            version += $"-{prereleaseSuffix}";
+        if (buildmetaSuffix != null)
+            version += $"+{buildmetaSuffix}";
+
+        return version;
     }
 
     public static string GetUpmName(this NuspecReader nuspecReader)

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -96,11 +96,16 @@ public static class NuspecReaderExtension
         return new PublishingConfiguration() { Registry = targetRegistry.ToString(), };
     }
 
-    public static string GenerateUpmReadme(this NuspecReader nuspecReader, AssemblyName assemblyName)
+    public static string GenerateUpmReadme(
+        this NuspecReader nuspecReader,
+        AssemblyName assemblyName,
+        string? prereleaseSuffix = null,
+        string? buildmetaSuffix = null
+    )
     {
         return ReadmeStringFactory.GenerateReadme(
             name: $"{nuspecReader.GetUpmName()} ({nuspecReader.GetUpmPackageName()})",
-            version: nuspecReader.GetUpmVersion(),
+            version: nuspecReader.GetUpmVersion(prereleaseSuffix, buildmetaSuffix),
             description: nuspecReader.GetDescription(),
             applicationName: assemblyName.Name,
             applicationVersion: assemblyName.Version.ToString()

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -147,14 +147,16 @@ public static class NuspecReaderExtension
         this NuspecReader nuspecReader,
         string framework,
         Uri targetRegistry,
-        AssemblyName assemblyName
+        AssemblyName assemblyName,
+        string? prereleaseSuffix = null,
+        string? buildmetaSuffix = null
     )
     {
         PackageJson packageJson =
             new()
             {
                 Name = nuspecReader.GetUpmPackageName(),
-                Version = nuspecReader.GetUpmVersion(),
+                Version = nuspecReader.GetUpmVersion(prereleaseSuffix, buildmetaSuffix),
                 License = nuspecReader.GetLicenseMetadata()?.License,
                 Description = nuspecReader.GetDescription(),
                 Keywords = nuspecReader.GetUpmKeywords(),

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -35,6 +35,8 @@ public static partial class Program
             SourceRepositoryOption,
             TargetRegistryOption,
             OutputDirectoryOption,
+            UpmPrereleaseSuffixOption,
+            UpmBuildmetaSuffixOption,
         }.WithHandler(CommandHandler.Create(UpmPack));
 
     private static async Task<int> UpmPack(
@@ -46,6 +48,8 @@ public static partial class Program
         Uri source,
         Uri target,
         DirectoryInfo outputDirectory,
+        string? prereleaseSuffix,
+        string? buildmetaSuffix,
         IConsole console,
         CancellationToken cancellationToken
     )
@@ -57,6 +61,8 @@ public static partial class Program
             latest: latest,
             version: version,
             framework: framework,
+            prereleaseSuffix: prereleaseSuffix,
+            buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Completions;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+using System.CommandLine.NamingConventionBinder;
+using System.CommandLine.Parsing;
+
+namespace NuGettier;
+
+public static partial class Program
+{
+    private static Option<string> UpmPrereleaseSuffixOption =
+        new(
+            aliases: new string[] { "--prerelease-suffix", },
+            description: "version prerelease suffix ('foobar' -> '1.2.3-foobar+buildmeta)"
+        );
+
+    private static Option<string> UpmBuildmetaSuffixOption =
+        new(
+            aliases: new string[] { "--buildmeta-suffix", },
+            description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)"
+        );
+}


### PR DESCRIPTION
- feature (NuGettier): add upm-specific options --prerelease-suffix and --buildmeta-suffix
- feature (NuGettier.Upm): implement NuspecReader extension method .GetUpmVersion()
- refactor (NuGettier.Upm): use NuspecReader.GetUpmVersion instead of NuspecReader.GetVersion
- refactor (NuGettier.Upm): add string? arguments 'prereleaseSuffix' and 'buildmetaSuffix' to NuspecReader.GenerateUpmReadme extension method
- refactor (NuGettier.Upm): add string? arguments 'prereleaseSuffix' and 'buildmetaSuffix' to NuspecReader.GenerateUpmLicense extension method
- refactor (NuGettier.Upm): add string? arguments 'prereleaseSuffix' and 'buildmetaSuffix' to NuspecReader.GenerateUpmChangelog extension method
- refactor (NuGettier.Upm): add string? arguments 'prereleaseSuffix' and 'buildmetaSuffix' to NuspecReader.GenerateUpmPackageJson extension method
- refactor (NuGettier.Upm): add string? arguments 'prereleaseSuffix' and 'buildmetaSuffix' to Context.PackUpmPackage
