### PR TITLE
refactor/upm dependency handling

### DIFF
--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -92,6 +92,17 @@ public partial class Context
                 framework: selectedFramework,
                 targetRegistry: target,
                 assemblyName: assemblyName,
+                async (dependencyPackageName, dependencyPackageVersion) =>
+                {
+                    var dependencyPackage = await GetPackageInformation(
+                        packageName: dependencyPackageName,
+                        preRelease: true,
+                        latest: false,
+                        version: dependencyPackageVersion,
+                        cancellationToken: cancellationToken
+                    );
+                    return ((IPackageSearchMetadata)dependencyPackage!).GetUpmPackageName();
+                },
                 prereleaseSuffix: prereleaseSuffix,
                 buildmetaSuffix: buildmetaSuffix
             );

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -100,7 +100,9 @@ public partial class Context
             packageJson.Files.AddRange(files.Keys);
 
             // add package.json
-            files.Add("package.json", packageJson.ToJson());
+            var packageJsonString = packageJson.ToJson();
+            files.Add("package.json", packageJsonString);
+            Console.WriteLine($"--- PACKAGE.JSON\n{packageJsonString}\n---");
 
             // add meta files
             files.AddMetaFiles(packageJson.Name);

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -149,6 +149,7 @@ public static class NuspecReaderExtension
         string framework,
         Uri targetRegistry,
         AssemblyName assemblyName,
+        Func<string, string, Task<string?>> getDependencyName,
         string? prereleaseSuffix = null,
         string? buildmetaSuffix = null
     )
@@ -164,7 +165,7 @@ public static class NuspecReaderExtension
                 DisplayName = nuspecReader.GetUpmDisplayName(framework, assemblyName),
                 Repository = nuspecReader.GetUpmRepository(),
                 PublishingConfiguration = nuspecReader.GetUpmPublishingConfiguration(targetRegistry),
-                Dependencies = nuspecReader.GetUpmDependencies(framework),
+                Dependencies = nuspecReader.GetUpmDependencies(framework, getDependencyName),
             };
 
         return packageJson;

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -68,7 +68,8 @@ public static class NuspecReaderExtension
 
     public static StringStringDictionary GetUpmDependencies(
         this NuspecReader nuspecReader,
-        string framework
+        string framework,
+        Func<string, string, Task<string?>> getDependencyName
     )
     {
         return new StringStringDictionary(

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -66,12 +66,12 @@ public static class NuspecReaderExtension
         return new Author() { Name = nuspecReader.GetAuthors(), Url = nuspecReader.GetProjectUrl(), };
     }
 
-    public static PackageJson.StringStringDictionary GetUpmDependencies(
+    public static StringStringDictionary GetUpmDependencies(
         this NuspecReader nuspecReader,
         string framework
     )
     {
-        return new PackageJson.StringStringDictionary(
+        return new StringStringDictionary(
             nuspecReader
                 .GetDependencyGroups()
                 .Where(d => d.TargetFramework.GetShortFolderName() == framework)

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -78,7 +78,7 @@ public static class NuspecReaderExtension
                 .Where(d => d.TargetFramework.GetShortFolderName() == framework)
                 .SelectMany(d => d.Packages)
                 .ToDictionary(
-                    p => p.Id, // TODO: use GetUpmPackageName
+                    p => (getDependencyName(p.Id, p.VersionRange.ToLegacyShortString())).Result,
                     p => p.VersionRange.ToLegacyShortString()
                 )
         );


### PR DESCRIPTION
- refactor (NuGettier.Upm): output generated package.json to log
- refactor (NuGettier.Upm): replace reference to PackageJson.StringStringDictionary -> StringStringDictionary
- refactor (NuGettier.Upm): add async delegate to NuspecReader.GetUpmDependencies extension method signature
- refactor (NuGettier.Upm): call into async delegate from NuspecReader.GetUpmDependencies
- refactor (NuGettier.Upm): add async delegate to NuspecReader.GenerateUpmPackageJson extension method signature
- refactor (NuGettier.Upm): implement async delegate calling Context.GetPackageInformation to handle dependency naming
