### PR TITLE
feature (NuGettier): implement upm 'publish' functionality

### DIFF
--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -118,7 +118,7 @@ public partial class Context
             // add meta files
             files.AddMetaFiles(packageJson.Name);
 
-            var packageIdentifier = $"{packageJson.Name}.{packageJson.Version}";
+            var packageIdentifier = $"{packageJson.Name}-{packageJson.Version}";
             return new Tuple<string, FileDictionary>(packageIdentifier, files);
         }
 

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text;
+using System.Text.Json;
+using System.Reflection;
+using System.CommandLine;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using ICSharpCode.SharpZipLib.Tar;
+using ICSharpCode.SharpZipLib.GZip;
+using NuGettier.Upm.TarGz;
+
+namespace NuGettier.Upm;
+
+public partial class Context
+{
+    public async Task<int> PublishUpmPackage(
+        string packageName,
+        bool preRelease,
+        bool latest,
+        string? version,
+        string? framework,
+        string? prereleaseSuffix,
+        string? buildmetaSuffix,
+        string token,
+        CancellationToken cancellationToken
+    )
+    {
+        var tuple = await PackUpmPackage(
+            packageName: packageName,
+            preRelease: preRelease,
+            latest: latest,
+            version: version,
+            framework: framework,
+            prereleaseSuffix: prereleaseSuffix,
+            buildmetaSuffix: buildmetaSuffix,
+            cancellationToken: cancellationToken
+        );
+
+        if (tuple == null)
+            return -1;
+
+        var (packageIdentifier, package) = tuple!;
+        using (package)
+        {
+            int exitCode = -2;
+            var tempDir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+            var packageFile = $"{packageIdentifier}.tgz";
+            await package.WriteToTarGzAsync(Path.Join(tempDir, packageFile));
+
+            using (var npmrcWriter = new StreamWriter(File.OpenWrite(Path.Join(tempDir, ".npmrc"))))
+            {
+                // format is "//${schemeless_registry}/:_authToken=${token}"
+                npmrcWriter.WriteLine($"//{target.SchemelessUri()}:_authToken={token}");
+            }
+
+            try
+            {
+                using var process = new System.Diagnostics.Process();
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.CreateNoWindow = true;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.StartInfo.FileName = @"npm";
+                process.StartInfo.WorkingDirectory = tempDir;
+
+                process.StartInfo.Arguments = string.Join(
+                    " ",
+                    "publish",
+                    packageFile,
+                    $"--registry={target.SchemelessUri()}",
+                    "--dry-run", // TODO: add argument `--n/--dry-run`
+                    "--verbose",
+                    "--access public" // TODO: add argument `--access [restricted|public]`
+                );
+
+                process.Start();
+                await process.WaitForExitAsync(cancellationToken);
+                exitCode = process.ExitCode;
+                var stdout = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+                var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+
+                if (!string.IsNullOrEmpty(stdout))
+                    Console.WriteLine($"NPM: {stdout}");
+
+                if (!string.IsNullOrEmpty(stderr))
+                    Console.Error.WriteLine($"NPM: {stderr}");
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine($"NPM: {e.Message}");
+            }
+
+            Directory.Delete(tempDir, recursive: true);
+            return exitCode;
+        }
+    }
+}

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace NuGettier.Upm;
+
+public static class UriExtension
+{
+    /// <summary>
+    /// allows to get the schemeless Uri as required by `npm`
+    /// https://my-awesome-server/npmapi -> my-awesome-server/npmapi
+    /// </summary>
+    /// <returns>Uri.AbsoluteUri without the scheme</returns>
+    public static string SchemelessUri(this Uri uri)
+    {
+        return uri.AbsoluteUri.Replace($"{uri.Scheme}//", "");
+    }
+}

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -23,7 +23,7 @@ public static partial class Program
             UpmCommand,
         };
         cmd.Name = "dotnet-nugettier";
-        cmd.Description = "Extended NuGet helper util";
+        cmd.Description = "Extended NuGet helper utility";
 
         return await cmd.InvokeAsync(args);
     }

--- a/NuGettier/UpmActions/Upm.cs
+++ b/NuGettier/UpmActions/Upm.cs
@@ -17,5 +17,6 @@ public static partial class Program
         {
             UpmPackCommand,
             UpmUnpackCommand,
+            UpmPublishCommand,
         };
 }

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+
+namespace NuGettier;
+
+public static partial class Program
+{
+    private static Command UpmPublishCommand =>
+        new Command("publish", "repack the given NuPkg at the given version as Unity package and publish")
+        {
+            PackageNameArgument,
+            IncludePrereleaseOption,
+            RetrieveLatestOption,
+            SpecificVersionOption,
+            FrameworkOption,
+            SourceRepositoryOption,
+            TargetRegistryOption,
+            UpmPrereleaseSuffixOption,
+            UpmBuildmetaSuffixOption,
+            UpmToken,
+        }.WithHandler(CommandHandler.Create(UpmPublish));
+
+    private static async Task<int> UpmPublish(
+        string packageName,
+        bool preRelease,
+        bool latest,
+        string version,
+        string framework,
+        Uri source,
+        Uri target,
+        string? prereleaseSuffix,
+        string? buildmetaSuffix,
+        string token,
+        IConsole console,
+        CancellationToken cancellationToken
+    )
+    {
+        using var context = new Upm.Context(source: source, target: target, console: console);
+        var result = await context.PublishUpmPackage(
+            packageName: packageName,
+            preRelease: preRelease,
+            latest: latest,
+            version: version,
+            framework: framework,
+            prereleaseSuffix: prereleaseSuffix,
+            buildmetaSuffix: buildmetaSuffix,
+            token: token,
+            cancellationToken: cancellationToken
+        );
+
+        if (result != 0)
+        {
+            console.Error.WriteLine($"publishing failed");
+        }
+
+        return result;
+    }
+}

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -23,4 +23,10 @@ public static partial class Program
             aliases: new string[] { "--buildmeta-suffix", },
             description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)"
         );
+
+    private static Option<string> UpmToken =
+        new(aliases: new string[] { "--token", }, description: "authentication token required to connect to NPM server")
+        {
+            IsRequired = true,
+        };
 }


### PR DESCRIPTION
- refactor (NuGettier.Upm): correct packageIdentifier format to match output of 'npm pack'
- feature (NuGettier.Upm): add option to provide NPM auth token
- feature (NuGettier.Upm): implement Uri extension method to retrive the schemeless Uri as required by 'npm'
- feature (NuGettier.Upm): implement PublishUpmPackage as call to `npm publish`
- feature (NuGettier): implement 'UpmPublish' action
- fix (NuGettier): improve wording in application description

