### PR TITLE
ci: support publishing to NuGet.org

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,13 +5,17 @@ inputs:
     default: Debug
   framework:
     required: true
+  exclude:
+    required: false
 runs:
   using: composite
   steps:
   - name: Build (${{ inputs.configuration }}) ${{ inputs.framework }}
     shell: pwsh
     run: |-
-      foreach ($project in @(fdfind "csproj$"))
+      $exclude = "${{ inputs.exclude }}"
+      $excludeArg = [string]::IsNullOrEmpty($exclude) ? "" : "--exclude"
+      foreach ($project in @(fdfind $excludeArg $exclude "csproj$"))
       {
         echo "building $project"
         dotnet build -f ${{ inputs.framework }} -c ${{ inputs.configuration }} $project

--- a/.github/jobactions/build/action.yml
+++ b/.github/jobactions/build/action.yml
@@ -5,6 +5,8 @@ inputs:
     default: Debug
   framework:
     required: true
+  exclude:
+    required: false
 runs:
   using: composite
   steps:
@@ -15,3 +17,4 @@ runs:
     with:
       framework: ${{ inputs.framework }}
       configuration: ${{ inputs.configuration }}
+      exclude: ${{ inputs.exclude }}

--- a/.github/jobactions/nuget-prepare-publish/action.yml
+++ b/.github/jobactions/nuget-prepare-publish/action.yml
@@ -24,6 +24,7 @@ runs:
     with:
       framework: net7.0
       configuration: Release
+      exclude: Prototype
   - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
     with:
       framework: net7.0

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -42,10 +42,24 @@ jobs:
 
   test-nuget:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        source: [nuget, github]
+        include:
+          - source: nuget
+            registry: https://api.nuget.org/v3/index.json
+            username: KageKirin
+            token: NUGET_ORG_TOKEN
+          - source: github
+            registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+            username: ${{ github.repository_owner }}
+            token: GH_NUGET_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/jobactions/nuget-prepare-publish
       with:
-        name: github-nuget
-        token: ${{ secrets.GH_NUGET_TOKEN }}
+        name: ${{ matrix.source }}
+        registry: ${{ matrix.registry }}
+        username: ${{ matrix.username }}
+        token: ${{ secrets[matrix.token] }}

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -25,13 +25,27 @@ jobs:
 
   test-nuget:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        source: [nuget, github]
+        include:
+          - source: nuget
+            registry: https://api.nuget.org/v3/index.json
+            username: KageKirin
+            token: NUGET_ORG_TOKEN
+          - source: github
+            registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+            username: ${{ github.repository_owner }}
+            token: GH_NUGET_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/jobactions/nuget-prepare-publish
       with:
-        name: github-nuget
-        token: ${{ secrets.GH_NUGET_TOKEN }}
+        name: ${{ matrix.source }}
+        registry: ${{ matrix.registry }}
+        username: ${{ matrix.username }}
+        token: ${{ secrets[matrix.token] }}
 
 
   ### TODO: do not tag here, instead create a branch, update dependencies (dotnet )

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -46,13 +46,27 @@ jobs:
 
   test-nuget:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        source: [nuget, github]
+        include:
+          - source: nuget
+            registry: https://api.nuget.org/v3/index.json
+            username: KageKirin
+            token: NUGET_ORG_TOKEN
+          - source: github
+            registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+            username: ${{ github.repository_owner }}
+            token: GH_NUGET_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/jobactions/nuget-prepare-publish
       with:
-        name: github-nuget
-        token: ${{ secrets.GH_NUGET_TOKEN }}
+        name: ${{ matrix.source }}
+        registry: ${{ matrix.registry }}
+        username: ${{ matrix.username }}
+        token: ${{ secrets[matrix.token] }}
 
   test-update-dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,14 +25,28 @@ jobs:
 
   nuget:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        source: [nuget, github]
+        include:
+          - source: nuget
+            registry: https://api.nuget.org/v3/index.json
+            username: KageKirin
+            token: NUGET_ORG_TOKEN
+          - source: github
+            registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+            username: ${{ github.repository_owner }}
+            token: GH_NUGET_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/jobactions/nuget-prepare-publish
       with:
-        name: github-nuget
-        token: ${{ secrets.GH_NUGET_TOKEN }}
+        name: ${{ matrix.source }}
+        registry: ${{ matrix.registry }}
+        username: ${{ matrix.username }}
+        token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-dotnet/.github/actions/nuget-publish@main
       with:
-        registry: github-nuget
-        token: ${{ secrets.GH_NUGET_TOKEN }}
+        registry: ${{ matrix.registry }}
+        token: ${{ secrets[matrix.token] }}


### PR DESCRIPTION
- refactor ('build' action): add input 'exclude' to exclude specific folders from build
- refactor ('build' job action): add input 'exclude' to exclude specific folders from build
- refactor ('nuget-prepare-publish' jobaction): exclude building 'Prototype' project
- refactor ('build-pr/test-nuget' job): adapt to matrix build to run for both github and nuget.org as sources
- refactor ('build-cron/test-nuget' job): adapt to matrix build to run for both github and nuget.org as sources
- refactor ('build-ci/test-nuget' job): adapt to matrix build to run for both github and nuget.org as sources
- refactor ('publish/nuget' job): adapt to matrix build to publish packages to both github and nuget.org
