### PR TITLE
refactor ('install' action): install NuGettier from NuGet.org feed

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -12,7 +12,6 @@ runs:
   - name: Install
     shell: bash
     run: |-
-      dotnet nuget add source --username ${{ github.actor }} --password ${{ github.token }} --store-password-in-clear-text --name kagekirin-github "https://nuget.pkg.github.com/KageKirin/index.json"
       dotnet tool install NuGettier -g
   - name: Verify installation
     shell: bash

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -12,7 +12,7 @@ runs:
   - name: Install
     shell: bash
     run: |-
-      dotnet tool install NuGettier -g
+      dotnet tool install NuGettier -g --prerelease
   - name: Verify installation
     shell: bash
     run: |-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,3 +50,9 @@ jobs:
       with:
         registry: ${{ matrix.registry }}
         token: ${{ secrets[matrix.token] }}
+
+  test-install:
+    runs-on: ubuntu-latest
+    needs: nuget
+    steps:
+    - uses: kagekirin/nugettier/.github/actions/install@main


### PR DESCRIPTION
- refactor ('install' action): install NuGettier from default source (NuGet.org)
- refactor ('install' action): install NuGettier with --prerelease option
- refactor ('publish' workflow): add job 'test-install' to run after 'nuget' for testing published package
