### PR TITLE
refactor (NuGettier.Core): sort package metadata by version before returning

### DIFF
--- a/NuGettier.Core/GetPackageVersions.cs
+++ b/NuGettier.Core/GetPackageVersions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json;
@@ -27,7 +28,7 @@ public partial class Context
         PackageMetadataResource resource = await Repository.GetResourceAsync<PackageMetadataResource>(
             cancellationToken
         );
-        return await resource.GetMetadataAsync(
+        var packages = await resource.GetMetadataAsync(
             packageName,
             includePrerelease: preRelease,
             includeUnlisted: false,
@@ -35,5 +36,6 @@ public partial class Context
             NullLogger.Instance,
             cancellationToken
         );
+        return packages.OrderByDescending(p => p.Identity.Version);
     }
 }


### PR DESCRIPTION
reason: package metadata order depends on repository
        -> nuget.org returns ascending (lowest to greatest)
        -> github returns descending (greatest to lowest)
        ==> always sort by descending order, so that .First() is the latest version
