### PR TITLE
fix ('tag' jobaction): pass correct quadruplet RegEx to csproj-version

### DIFF
--- a/.github/jobactions/tag/action.yml
+++ b/.github/jobactions/tag/action.yml
@@ -43,10 +43,16 @@ runs:
 
       foreach ($project in @(fdfind "csproj$"))
       {
+        $revision = "$(git rev-list --all --count -- $project)"
+        $assemblyVersion = "$version.${{ github.run_id }}"
+        $fileVersion = "$version.$revision"
         echo "patching $project"
+        echo "assembly version: $assemblyVersion"
+        echo "file version: $fileVersion"
+
         csproj-version set --version $version $project
-        csproj-version set --version $version.${{ github.run_id }} --xpath '//PropertyGroup/AssemblyVersion' --regex $mmpr_regex $project
-        csproj-version set --version $version.$(git rev-list --all --count -- $project) --xpath '//PropertyGroup/FileVersion' --regex $mmpr_regex $project
+        csproj-version set --version $assemblyVersion --xpath '//PropertyGroup/AssemblyVersion' --regex "$mmpr_regex" $project
+        csproj-version set --version $fileVersion     --xpath '//PropertyGroup/FileVersion'     --regex "$mmpr_regex" $project
         git add $project
       }
 

--- a/.github/jobactions/tag/action.yml
+++ b/.github/jobactions/tag/action.yml
@@ -37,7 +37,7 @@ runs:
       git --no-pager status
       git --no-pager tag -l --sort=-v:refname | head -n 1
 
-      $mmpr_regex = "^(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)\\.(?<revision>0|[1-9]\\d*)"
+      $mmpr_regex = '^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)\.(?<revision>0|[1-9]\d*)'
       $version = "${{ steps.update-git-tag.outputs.version }}"
       echo "Version: $version"
 
@@ -51,8 +51,8 @@ runs:
         echo "file version: $fileVersion"
 
         csproj-version set --version $version $project
-        csproj-version set --version $assemblyVersion --xpath '//PropertyGroup/AssemblyVersion' --regex "$mmpr_regex" $project
-        csproj-version set --version $fileVersion     --xpath '//PropertyGroup/FileVersion'     --regex "$mmpr_regex" $project
+        csproj-version set --version $assemblyVersion --xpath '//PropertyGroup/AssemblyVersion' --regex $mmpr_regex $project
+        csproj-version set --version $fileVersion     --xpath '//PropertyGroup/FileVersion'     --regex $mmpr_regex $project
         git add $project
       }
 


### PR DESCRIPTION
- fix ('tag' jobaction): fix calls to csproj-version with version quadruplet
- fix ('tag' jobaction): fix quadruplet version regex
