### PR TITLE
build: add dependency on Xunit

### DIFF
--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="NuGet.Resolver" Version="6.7.0"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
+    <PackageReference Include="Xunit" Version="2.5.3"/>
   </ItemGroup>
 
   <ItemGroup Label="packaged files">

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.Text.Json" Version="7.0.3"/>
+    <PackageReference Include="Xunit" Version="2.5.3"/>
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="NuGet.Resolver" Version="6.7.0"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
+    <PackageReference Include="Xunit" Version="2.5.3"/>
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="NuGet.Packaging" Version="6.7.0"/>
     <PackageReference Include="NuGet.Protocol" Version="6.7.0"/>
     <PackageReference Include="NuGet.Resolver" Version="6.7.0"/>
+    <PackageReference Include="Xunit" Version="2.5.3"/>
   </ItemGroup>
 
   <ItemGroup Label="embedded resources">


### PR DESCRIPTION
- build (NuGettier): add dependency on Xunit (version 2.5.3)
- build (NuGettier.Core): add dependency on Xunit (version 2.5.3)
- build (NuGettier.Upm): add dependency on Xunit (version 2.5.3)
- build (Prototype): add dependency on Xunit (version 2.5.3)
