### PR TITLE
fix ('tag' jobaction): fix overly long version.revision

### DIFF
--- a/.github/jobactions/tag/action.yml
+++ b/.github/jobactions/tag/action.yml
@@ -44,7 +44,7 @@ runs:
       foreach ($project in @(fdfind "csproj$"))
       {
         $revision = "$(git rev-list --all --count -- $project)"
-        $assemblyVersion = "$version.${{ github.run_id }}"
+        $assemblyVersion = "$version.${{ github.run_number }}"
         $fileVersion = "$version.$revision"
         echo "patching $project"
         echo "assembly version: $assemblyVersion"

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup Label="version metadata">
     <Version>0.0.41</Version>
-    <AssemblyVersion>0.0.41.6649374659</AssemblyVersion>
+    <AssemblyVersion>0.0.41.0</AssemblyVersion>
     <FileVersion>0.0.41.32</FileVersion>
   </PropertyGroup>
 

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup Label="version metadata">
     <Version>0.0.41</Version>
-    <AssemblyVersion>0.0.41.6649374659</AssemblyVersion>
+    <AssemblyVersion>0.0.41.0</AssemblyVersion>
     <FileVersion>0.0.41.103</FileVersion>
   </PropertyGroup>
 

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup Label="version metadata">
     <Version>0.0.41</Version>
-    <AssemblyVersion>0.0.41.6649374659</AssemblyVersion>
+    <AssemblyVersion>0.0.41.0</AssemblyVersion>
     <FileVersion>0.0.41.52</FileVersion>
   </PropertyGroup>
 

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup Label="version metadata">
     <Version>0.0.41</Version>
-    <AssemblyVersion>0.0.41.6649374659</AssemblyVersion>
+    <AssemblyVersion>0.0.41.0</AssemblyVersion>
     <FileVersion>0.0.41.196</FileVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
reason: limited to 65535 max (https://learn.microsoft.com/en-us/archive/blogs/msbuild/why-are-build-numbers-limited-to-65535)
