### PR TITLE
fix (NuGettier.Upm): avoid duplicate file addition in UpmPack

### DIFF
--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -74,8 +74,11 @@ public partial class Context
 
             // create & add README
             var readme = nuspecReader.GenerateUpmReadme(assemblyName, prereleaseSuffix, buildmetaSuffix);
-            files.Add("README.md", readme);
-            Console.WriteLine($"--- README\n{readme}\n---");
+            if (!files.ContainsKey(@"README.md"))
+            {
+                files.Add(@"README.md", readme);
+                Console.WriteLine($"--- README\n{Encoding.Default.GetString(files[@"README.md"])}\n---");
+            }
 
             // create & add LICENSE
             var license = nuspecReader.GenerateUpmLicense(prereleaseSuffix, buildmetaSuffix);

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -82,8 +82,11 @@ public partial class Context
 
             // create & add LICENSE
             var license = nuspecReader.GenerateUpmLicense(prereleaseSuffix, buildmetaSuffix);
-            files.Add("LICENSE.md", license);
-            Console.WriteLine($"--- LICENSE\n{license}\n---");
+            if (!files.ContainsKey(@"LICENSE.md"))
+            {
+                files.Add(@"LICENSE.md", license);
+                Console.WriteLine($"--- LICENSE\n{Encoding.Default.GetString(files[@"LICENSE.md"])}\n---");
+            }
 
             // create & add CHANGELOG
             var changelog = nuspecReader.GenerateUpmChangelog(prereleaseSuffix, buildmetaSuffix);

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -90,8 +90,11 @@ public partial class Context
 
             // create & add CHANGELOG
             var changelog = nuspecReader.GenerateUpmChangelog(prereleaseSuffix, buildmetaSuffix);
-            files.Add("CHANGELOG.md", changelog);
-            Console.WriteLine($"--- CHANGELOG\n{changelog}\n---");
+            if (!files.ContainsKey(@"CHANGELOG.md"))
+            {
+                files.Add(@"CHANGELOG.md", license);
+                Console.WriteLine($"--- CHANGELOG\n{Encoding.Default.GetString(files[@"CHANGELOG.md"])}\n---");
+            }
 
             // create package.json
             var packageJson = nuspecReader.GenerateUpmPackageJson(


### PR DESCRIPTION
- refactor (NuGettier.Upm): avoid adding README.md to package files when it already exists
- refactor (NuGettier.Upm): avoid adding LICENSE.md to package files when it already exists
- refactor (NuGettier.Upm): avoid adding CHANGELOG.md to package files when it already exists
