### PR TITLE
feature: implement support for configuration files

### DIFF
--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -10,6 +10,7 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Microsoft.Extensions.Configuration;
+using Xunit;
 
 namespace NuGettier.Core;
 
@@ -25,6 +26,7 @@ public partial class Context : IDisposable
 
     public Context(IConfigurationRoot configuration, IEnumerable<Uri> sources, IConsole console)
     {
+        Assert.NotNull(configuration);
         Configuration = configuration;
         Console = console;
         Sources = sources;

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -9,6 +9,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using Microsoft.Extensions.Configuration;
 
 namespace NuGettier.Core;
 
@@ -16,13 +17,15 @@ namespace NuGettier.Core;
 
 public partial class Context : IDisposable
 {
+    public IConfigurationRoot Configuration { get; protected set; }
     public IEnumerable<Uri> Sources { get; protected set; }
     public SourceCacheContext Cache { get; protected set; }
     public IEnumerable<SourceRepository> Repositories { get; protected set; }
     public IConsole Console { get; set; }
 
-    public Context(IEnumerable<Uri> sources, IConsole console)
+    public Context(IConfigurationRoot configuration, IEnumerable<Uri> sources, IConsole console)
     {
+        Configuration = configuration;
         Console = console;
         Sources = sources;
         Cache = new();

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -79,5 +79,14 @@ public partial class Context : IDisposable
         });
     }
 
+    public Context(Context other)
+    {
+        Configuration = other.Configuration;
+        Console = other.Console;
+        Sources = other.Sources;
+        Cache = other.Cache;
+        Repositories = other.Repositories;
+    }
+
     public void Dispose() { }
 }

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="package dependencies">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.7.0"/>

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -14,4 +14,10 @@ public partial class Context : Core.Context
     {
         this.Target = target;
     }
+
+    public Context(Context other)
+        : base(other)
+    {
+        Target = other.Target;
+    }
 }

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -1,6 +1,7 @@
 using System;
 using System.CommandLine;
 using NuGettier;
+using Microsoft.Extensions.Configuration;
 
 namespace NuGettier.Upm;
 
@@ -8,8 +9,8 @@ public partial class Context : Core.Context
 {
     public Uri Target { get; protected set; }
 
-    public Context(IEnumerable<Uri> sources, Uri target, IConsole console)
-        : base(sources, console)
+    public Context(IConfigurationRoot configuration, IEnumerable<Uri> sources, Uri target, IConsole console)
+        : base(configuration, sources, console)
     {
         this.Target = target;
     }

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.7.0"/>

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using Xunit;
 
 namespace NuGettier;
 
@@ -46,6 +47,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
+        Assert.NotNull(Configuration);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         using var packageStream = await context.FetchPackage(
             packageName: packageName,

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -46,7 +46,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
-        using var context = new Core.Context(sources: sources, console: console);
+        using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         using var packageStream = await context.FetchPackage(
             packageName: packageName,
             preRelease: preRelease,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -45,7 +45,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
-        using var context = new Core.Context(sources: sources, console: console);
+        using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var package = await context.GetPackageInformation(
             packageName: packageName,
             preRelease: preRelease,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using Xunit;
 
 namespace NuGettier;
 
@@ -45,6 +46,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
+        Assert.NotNull(Configuration);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var package = await context.GetPackageInformation(
             packageName: packageName,

--- a/NuGettier/CoreActions/List.cs
+++ b/NuGettier/CoreActions/List.cs
@@ -39,7 +39,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
-        using var context = new Core.Context(sources: sources, console: console);
+        using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var results = await context.GetPackageVersions(
             packageName: packageName,
             preRelease: preRelease,

--- a/NuGettier/CoreActions/List.cs
+++ b/NuGettier/CoreActions/List.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using Xunit;
 
 namespace NuGettier;
 
@@ -39,6 +40,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
+        Assert.NotNull(Configuration);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var results = await context.GetPackageVersions(
             packageName: packageName,

--- a/NuGettier/CoreActions/Search.cs
+++ b/NuGettier/CoreActions/Search.cs
@@ -37,7 +37,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
-        using var context = new Core.Context(sources: sources, console: console);
+        using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var results = await context.SearchPackages(searchTerm: searchTerm, cancellationToken: cancellationToken);
 
         if (json)

--- a/NuGettier/CoreActions/Search.cs
+++ b/NuGettier/CoreActions/Search.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using Xunit;
 
 namespace NuGettier;
 
@@ -37,6 +38,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
+        Assert.NotNull(Configuration);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var results = await context.SearchPackages(searchTerm: searchTerm, cancellationToken: cancellationToken);
 

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -27,6 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="package dependencies">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.7.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -27,6 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="package dependencies">
+    <PackageReference Include="DotNetConfig" Version="1.0.6"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup Label="package dependencies">
     <PackageReference Include="DotNetConfig" Version="1.0.6"/>
+    <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -43,7 +43,7 @@ public static partial class Program
         new(aliases: new string[] { "--source", "-s" }, description: "source NuGet repositories to fetch from")
         {
             Name = "sources",
-            IsRequired = true,
+            IsRequired = false,
             AllowMultipleArgumentsPerToken = false, //< explicitly one value per --source argument
             Arity = ArgumentArity.OneOrMore,
         };

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -23,7 +23,7 @@ public static partial class Program
             .AddDotNetConfig()
             .Build();
 
-        var cmd = new RootCommand
+        var cmd = new RootCommand("Extended NuGet helper utility")
         { //
             SearchCommand,
             ListCommand,
@@ -32,7 +32,6 @@ public static partial class Program
             UpmCommand,
         };
         cmd.Name = "dotnet-nugettier";
-        cmd.Description = "Extended NuGet helper utility";
 
         return await cmd.InvokeAsync(args);
     }

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -9,6 +9,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using DotNetConfig;
 using Microsoft.Extensions.Configuration;
+using Xunit;
 
 #nullable enable
 
@@ -32,6 +33,8 @@ public static partial class Program
 
     static async Task<int> Main(string[] args)
     {
+        Assert.NotNull(Configuration);
+
 
         var cmd = new RootCommand("Extended NuGet helper utility")
         { //

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -16,12 +16,22 @@ namespace NuGettier;
 
 public static partial class Program
 {
-    private static IConfigurationRoot? Configuration;
+    private static IConfigurationRoot? configurationRoot = null;
+    private static IConfigurationRoot Configuration
+    {
+        get
+        {
+            // Config.GlobalLocation = Path.Combine(Directory.GetCurrentDirectory(), "Content", "global.netconfig");
+            // Config.SystemLocation = Path.Combine(Directory.GetCurrentDirectory(), "Content", ".netconfig");
+            configurationRoot ??= new ConfigurationBuilder()
+                .AddDotNetConfig()
+                .Build();
+            return configurationRoot;
+        }
+    }
+
     static async Task<int> Main(string[] args)
     {
-        var Configuration = new ConfigurationBuilder()
-            .AddDotNetConfig()
-            .Build();
 
         var cmd = new RootCommand("Extended NuGet helper utility")
         { //

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -7,13 +7,22 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
+using DotNetConfig;
+using Microsoft.Extensions.Configuration;
+
+#nullable enable
 
 namespace NuGettier;
 
 public static partial class Program
 {
+    private static IConfigurationRoot? Configuration;
     static async Task<int> Main(string[] args)
     {
+        var Configuration = new ConfigurationBuilder()
+            .AddDotNetConfig()
+            .Build();
+
         var cmd = new RootCommand
         { //
             SearchCommand,

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -19,6 +19,7 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
+using Xunit;
 
 namespace NuGettier;
 
@@ -54,6 +55,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
+        Assert.NotNull(Configuration);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -54,7 +54,12 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
-        using var context = new Upm.Context(sources: sources, target: target, console: console);
+        using var context = new Upm.Context(
+            configuration: Configuration!,
+            sources: sources,
+            target: target,
+            console: console
+        );
         var tuple = await context.PackUpmPackage(
             packageName: packageName,
             preRelease: preRelease,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -46,7 +46,12 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
-        using var context = new Upm.Context(sources: sources, target: target, console: console);
+        using var context = new Upm.Context(
+            configuration: Configuration!,
+            sources: sources,
+            target: target,
+            console: console
+        );
         var result = await context.PublishUpmPackage(
             packageName: packageName,
             preRelease: preRelease,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -7,6 +7,7 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
+using Xunit;
 
 namespace NuGettier;
 
@@ -46,6 +47,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
+        Assert.NotNull(Configuration);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -19,6 +19,7 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
+using Xunit;
 
 namespace NuGettier;
 
@@ -54,6 +55,7 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
+        Assert.NotNull(Configuration);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -54,7 +54,12 @@ public static partial class Program
         CancellationToken cancellationToken
     )
     {
-        using var context = new Upm.Context(sources: sources, target: target, console: console);
+        using var context = new Upm.Context(
+            configuration: Configuration!,
+            sources: sources,
+            target: target,
+            console: console
+        );
         var tuple = await context.PackUpmPackage(
             packageName: packageName,
             preRelease: preRelease,


### PR DESCRIPTION
- build (NuGettier): add dependency on Microsoft.Extensions.Configuration (version 7.0.0)
- build (NuGettier): add dependency on DotNetConfig (version 1.0.6)
- build (NuGettier): add dependency on DotNetConfig.Configuration (version 1.0.6)
- feature (NuGettier): load configuration (.netconfig) via ConfigurationBuilder at program start
- refactor (NuGettier): set program description in root command ctor
- build (NuGettier.Core): add dependency on Microsoft.Extensions.Configuration (version 7.0.0)
- build (NuGettier.Upm): add dependency on Microsoft.Extensions.Configuration (version 7.0.0)
- feature (NuGettier.Core): add IConfigurationRoot as member variable to Core.Context, set via ctor
- feature (NuGettier.Upm): add IConfigurationRoot to Upm.Context ctor, pass to base class ctor
- refactor (NuGettier): pass Configuration to Core.Context ctor in Get command
- refactor (NuGettier): pass Configuration to Core.Context ctor in Info command
- refactor (NuGettier): pass Configuration to Core.Context ctor in List command
- refactor (NuGettier): pass Configuration to Core.Context ctor in Search command
- refactor (NuGettier): pass Configuration to Upm.Context ctor in UpmPack command
- refactor (NuGettier): pass Configuration to Upm.Context ctor in UpmPublish command
- refactor (NuGettier): pass Configuration to Upm.Context ctor in UpmUnpack command
- refactor (NuGettier): transform static variable Configuration into lazily created instance
- refactor (NuGettier): assert that Configuration is not null before passing it to Core.Context ctor in Get command
- refactor (NuGettier): assert that Configuration is not null before passing it to Core.Context ctor in Info command
- refactor (NuGettier): assert that Configuration is not null before passing it to Core.Context ctor in List command
- refactor (NuGettier): assert that Configuration is not null before passing it to Core.Context ctor in Search command
- refactor (NuGettier): assert that Configuration is not null before passing it to Upm.Context ctor in UpmPack command
- refactor (NuGettier): assert that Configuration is not null before passing it to Upm.Context ctor in UpmPublish command
- refactor (NuGettier): assert that Configuration is not null before passing it to Upm.Context ctor in UpmUnpack command
- refactor (NuGettier.Core): assert that input IConfigurationRoot is not null
- feature (NuGettier.Core): build Core.Context Sources and Repositories from CLI inputs as well as from configuration data
- refactor (NuGettier): change option '--source' to be non-required
- refactor (NuGettier): lazily load configuration at program start and make sure static Configuration exists
- feature (NuGettier.Core): implement Core.Context copy-ctor
- feature (NuGettier.Upm): implement Upm.Context copy-ctor
