### PR TITLE
build: adjust minor build settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
+    <IncludeSource>false</IncludeSource>
     <Deterministic>true</Deterministic>
     <SymbolPackageFormat>symbols.nupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,11 @@
 <Project>
 
+  <ItemGroup Label="ThisAssembly.Project">
+    <ProjectProperty Include="RepositoryBranch" />
+    <ProjectProperty Include="RepositorySha" />
+    <ProjectProperty Include="RepositoryCommit" />
+    <ProjectProperty Include="RepositoryRoot" />
+    <ProjectProperty Include="RepositoryUrl" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- build (props): set to not include source files
- file: add Directory.Build.targets
- build (targets): add repository info to target assembly
