### PR TITLE
refactor: adapt to option '--version' being actually optional

### DIFF
--- a/NuGettier.Core/Context/GetPackageInformation.cs
+++ b/NuGettier.Core/Context/GetPackageInformation.cs
@@ -24,7 +24,7 @@ public partial class Context
         string packageName,
         bool preRelease,
         bool latest,
-        string version,
+        string? version,
         CancellationToken cancellationToken
     )
     {
@@ -37,6 +37,10 @@ public partial class Context
         if (latest)
         {
             return packages.FirstOrDefault();
+        }
+        else if(version == null)
+        {
+            return null;
         }
 
         NuGetVersion cmpVersion = new(version);

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -40,7 +40,7 @@ public static partial class Program
         string packageName,
         bool preRelease,
         bool latest,
-        string version,
+        string? version,
         IEnumerable<Uri> sources,
         DirectoryInfo outputDirectory,
         IConsole console,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -39,7 +39,7 @@ public static partial class Program
         string packageName,
         bool preRelease,
         bool latest,
-        string version,
+        string? version,
         bool json,
         IEnumerable<Uri> sources,
         IConsole console,


### PR DESCRIPTION
- refactor (NuGettier.Core): Context.GetPackageInformation() to parameter 'version' being actually optional
- refactor (NuGettier): adapt Get command to '--version' being actually optional
- refactor (NuGettier): adapt Info command to '--version' being actually optional
