### PR TITLE
feature (NuGettier.Core): implement Core.Context.BuildInfo, fill from EntryAssembly

### DIFF
--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -19,6 +19,8 @@ namespace NuGettier.Core;
 
 public partial class Context : IDisposable
 {
+    public record class BuildInfo(string AssemblyName, string AssemblyVersion);
+
     public IConfigurationRoot Configuration { get; protected set; }
     public IEnumerable<Uri> Sources { get; protected set; }
     public SourceCacheContext Cache { get; protected set; }

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -26,7 +26,7 @@ public partial class Context : IDisposable
     public IEnumerable<Uri> Sources { get; protected set; }
     public SourceCacheContext Cache { get; protected set; }
     public IEnumerable<SourceRepository> Repositories { get; protected set; }
-    public IConsole Console { get; set; }
+    public IConsole Console { get; protected set; }
     public BuildInfo Build { get; protected set; }
 
     public Context(IConfigurationRoot configuration, IEnumerable<Uri> sources, IConsole console)

--- a/NuGettier.Core/Context/GetPackageInformation.cs
+++ b/NuGettier.Core/Context/GetPackageInformation.cs
@@ -34,13 +34,9 @@ public partial class Context
             cancellationToken: cancellationToken
         );
 
-        if (latest)
+        if (latest || string.IsNullOrEmpty(version))
         {
             return packages.FirstOrDefault();
-        }
-        else if(version == null)
-        {
-            return null;
         }
 
         NuGetVersion cmpVersion = new(version);

--- a/NuGettier.Core/Extensions/AssemblyExtension.cs
+++ b/NuGettier.Core/Extensions/AssemblyExtension.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace NuGettier.Core;
+
+#nullable enable
+
+public static class AssemblyExtension
+{
+    public static T? GetAssemblyAttribute<T>(this Assembly assembly)
+        where T : Attribute
+    {
+        object[] attributes = assembly.GetCustomAttributes(typeof(T), false);
+        if (attributes == null || attributes.Length == 0)
+            return null;
+        return attributes.OfType<T>().SingleOrDefault();
+    }
+}


### PR DESCRIPTION
- feature (NuGettier.Core): implement Core.Context.BuildInfo
- feature (NuGettier.Core): add instance of Core.Context.BuildInfo to Core.Context, fill from entry assembly
- feature (NuGettier.Core): implement Assembly.GetAssemblyAttribute<T>() extension method
- refactor (NuGettier.Core): protect Context.Console from being set outside of ctor
- refactor (NuGettier.Core): improve handling of empty/null 'version' in Context.GetPackageInformation()
