### PR TITLE
refactor (NuGettier.Upm): extend NuspecReader extension methods to use PackageRules

### DIFF
--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -59,7 +59,7 @@ public partial class Context
             files.AddRange(packageReader.GetAdditionalFiles(nuspecReader, renameOriginalMarkdownFiles: true));
 
             // create & add README
-            var readme = nuspecReader.GenerateUpmReadme(assemblyName, prereleaseSuffix, buildmetaSuffix);
+            var readme = nuspecReader.GenerateUpmReadme(assemblyName, PackageRules, prereleaseSuffix, buildmetaSuffix);
             if (!files.ContainsKey(@"README.md"))
             {
                 files.Add(@"README.md", readme);

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -98,6 +98,7 @@ public partial class Context
                     );
                     return ((IPackageSearchMetadata)dependencyPackage!).GetUpmPackageName();
                 },
+                PackageRules,
                 prereleaseSuffix: prereleaseSuffix,
                 buildmetaSuffix: buildmetaSuffix
             );

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -96,7 +96,7 @@ public partial class Context
                         version: dependencyPackageVersion,
                         cancellationToken: cancellationToken
                     );
-                    return ((IPackageSearchMetadata)dependencyPackage!).GetUpmPackageName();
+                    return ((IPackageSearchMetadata)dependencyPackage!).GetUpmPackageName(PackageRules);
                 },
                 PackageRules,
                 prereleaseSuffix: prereleaseSuffix,

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -147,6 +147,7 @@ public static class NuspecReaderExtension
         Uri targetRegistry,
         AssemblyName assemblyName,
         Func<string, string, Task<string?>> getDependencyName,
+        IEnumerable<Context.PackageRule> packageRules,
         string? prereleaseSuffix = null,
         string? buildmetaSuffix = null
     )

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -58,7 +58,7 @@ public static class NuspecReaderExtension
     {
         return nuspecReader.GetUpmName()
             + $" ({framework} DLL)"
-            + $" [repacked by {assemblyName.Name} v{assemblyName.Version.ToString()}]";
+            + $" [repacked by {assemblyName.Name} v{assemblyName.Version?.ToString()}]";
     }
 
     public static List<string> GetUpmKeywords(this NuspecReader nuspecReader)

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -92,16 +92,7 @@ public static class NuspecReaderExtension
                     p =>
                         new KeyValuePair<PackageDependency, Context.PackageRule>(
                             p,
-                            packageRules
-                                .Where(r => r.Id == p.Id)
-                                .FirstOrDefault(
-                                    new Context.PackageRule(
-                                        Id: p.Id,
-                                        IsIgnored: false,
-                                        Name: (getDependencyName(p.Id, p.VersionRange.ToLegacyShortString())).Result,
-                                        Version: string.Empty
-                                    )
-                                )
+                            packageRules.Where(r => r.Id == p.Id).FirstOrDefault(Upm.Context.DefaultPackageRule)
                         )
                 )
                 .Where(pr => !pr.Value.IsIgnored)

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -77,7 +77,8 @@ public static class NuspecReaderExtension
     public static StringStringDictionary GetUpmDependencies(
         this NuspecReader nuspecReader,
         string framework,
-        Func<string, string, Task<string?>> getDependencyName
+        Func<string, string, Task<string?>> getDependencyName,
+        IEnumerable<Context.PackageRule> packageRules
     )
     {
         return new StringStringDictionary(
@@ -175,7 +176,7 @@ public static class NuspecReaderExtension
                 DisplayName = nuspecReader.GetUpmDisplayName(framework, assemblyName),
                 Repository = nuspecReader.GetUpmRepository(),
                 PublishingConfiguration = nuspecReader.GetUpmPublishingConfiguration(targetRegistry),
-                Dependencies = nuspecReader.GetUpmDependencies(framework, getDependencyName),
+                Dependencies = nuspecReader.GetUpmDependencies(framework, getDependencyName, packageRules),
             };
 
         return packageJson;

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -96,6 +96,7 @@ public static class NuspecReaderExtension
     public static string GenerateUpmReadme(
         this NuspecReader nuspecReader,
         AssemblyName assemblyName,
+        IEnumerable<Context.PackageRule> packageRules,
         string? prereleaseSuffix = null,
         string? buildmetaSuffix = null
     )

--- a/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/NuspecReaderExtension.cs
@@ -86,6 +86,11 @@ public static class NuspecReaderExtension
                 .GetDependencyGroups()
                 .Where(d => d.TargetFramework.GetShortFolderName() == framework)
                 .SelectMany(d => d.Packages)
+                .Where(p =>
+                {
+                    bool? isIgnored = packageRules.Where(r => r.Id == p.Id).Select(r => r.IsIgnored).FirstOrDefault();
+                    return !(isIgnored ?? false); //< false if isIgnored==true, true else
+                })
                 .ToDictionary(
                     p => (getDependencyName(p.Id, p.VersionRange.ToLegacyShortString())).Result,
                     p => p.VersionRange.ToLegacyShortString()


### PR DESCRIPTION
- refactor (NuGettier.Upm): extend .GenerateUpmReadme() extension method with PackageRules
- refactor (NuGettier.Upm): extend .GenerateUpmPackageJson() extension method with PackageRules
- refactor (NuGettier.Upm): extend .GetUpmPackageName() extension method with PackageRules
- refactor (NuGettier.Upm): extend .GetUpmDependencies() extension method with PackageRules
- refactor (NuGettier.Upm): ignore dependency package when package rule.'ignore' is true
- refactor (NuGettier.Upm): improve dependency renaming algorithm in .GetUpmDependencies()
- refactor (NuGettier.Upm): make version access null-safe in NuspecReader.GetUpmDisplayName() extension method
- refactor (NuGettier.Upm): simplify packageRule selection in NuspecReader.GetUpmPackageName() extension method
