### PR TITLE
refactor (NuGettier.Upm): adapt Upm.Context.PackUpmPackage() to work based on PackageJson

### DIFF
--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -76,7 +76,7 @@ public static class PackageArchiveReaderExtension
                     f =>
                         new KeyValuePair<string, byte[]>(
                             renameOriginalMarkdownFiles && Path.GetExtension(f) == ".md"
-                                ? $"{Path.GetFileName(f)}.orig.{Path.GetExtension(f)}"
+                                ? $"{Path.GetFileNameWithoutExtension(f)}.orig{Path.GetExtension(f)}"
                                 : f,
                             packageReader.GetBytes(f)
                         )

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -63,6 +63,7 @@ public static class PackageArchiveReaderExtension
                 nuspecReader.GetReadme(),
                 nuspecReader.GetReleaseNotes(),
                 "LICENSE.TXT",
+                "LICENSE.md",
                 "LICENSE",
             };
 

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -100,4 +100,25 @@ public static class PackageArchiveReaderExtension
 
         return Encoding.Default.GetString(data);
     }
+
+    public static byte[]? GetLicenseFile(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
+    {
+        var packageFiles = packageReader.GetFiles();
+        foreach (var f in packageFiles)
+        {
+            if (Path.GetFileName(f).ToLowerInvariant() == @"license")
+                packageReader.GetBytes(f);
+        }
+
+        return null;
+    }
+
+    public static string GetLicense(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
+    {
+        byte[]? data = packageReader.GetLicenseFile(nuspecReader);
+        if (data == null || data.Length == 0)
+            return string.Empty;
+
+        return Encoding.Default.GetString(data);
+    }
 }

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Text;
 using NuGet.Packaging;
 
 namespace NuGettier.Upm;
@@ -81,5 +82,22 @@ public static class PackageArchiveReaderExtension
                         )
                 )
         );
+    }
+
+    public static byte[]? GetReadmeFile(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
+    {
+        if (string.IsNullOrEmpty(nuspecReader.GetReadme()))
+            return null;
+
+        return packageReader.GetBytes(nuspecReader.GetReadme());
+    }
+
+    public static string GetReadme(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
+    {
+        byte[]? data = packageReader.GetReadmeFile(nuspecReader);
+        if (data == null || data.Length == 0)
+            return string.Empty;
+
+        return Encoding.Default.GetString(data);
     }
 }

--- a/NuGettier.Upm/StringFactories/ChangelogFactory.cs
+++ b/NuGettier.Upm/StringFactories/ChangelogFactory.cs
@@ -16,7 +16,9 @@ public static class ChangelogStringFactory
             {
                 Name = name,
                 Version = version,
-                ReleaseNotes = Uri.IsWellFormedUriString(releaseNotes, UriKind.Absolute) ? $"[release notes]({releaseNotes})": releaseNotes,
+                ReleaseNotes = Uri.IsWellFormedUriString(releaseNotes, UriKind.Absolute)
+                    ? $"[release notes]({releaseNotes})"
+                    : releaseNotes,
             }
         );
     }


### PR DESCRIPTION
- refactor (NuGettier.Upm): extend possible license file names
- feature (NuGettier.Upm): implement PackageArchiveReader to extract Readme file contents
- feature (NuGettier.Upm): implement PackageArchiveReader to extract License file contents
- refactor (NuGettier.Upm): rewrite Upm.Context.PackUpmPackage() to derive contents from PackageJson
- fix (NuGettier.Upm): fix renamed file format
- chore: dotnet-csharpier pass
