### PR TITLE
build (props): replace PackageLicenseExpression with PackageLicenseFile

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
     <Company>KageKirin</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>CHANGELOG.md</PackageReleaseNotes>
-    <PackageLicenseExpression>BUSL-1.0 AND SSPL-1.0</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 


### PR DESCRIPTION
note: This reverts commit 62a562f9fdd78654e2df80e4713c86cf9d4faae7.

reason: nuget.org does not support the `MUSL-1.0` license under which NuGettier is being published,
        and fails at publishing on CI.
