### PR TITLE
refactor: fix remaining warnings

### DIFF
--- a/NuGettier.Upm/Context/Globals.cs
+++ b/NuGettier.Upm/Context/Globals.cs
@@ -21,7 +21,7 @@ public partial class Context
         "net462",
     };
 
-    public static PackageRule DefaultPackageRule =
+    public static readonly PackageRule DefaultPackageRule =
         new(
             Id: string.Empty,
             IsIgnored: false,

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -86,11 +86,11 @@ public static class IPackageSearchMetadataExtension
         return new Person() { Name = firstAuthor, };
     }
 
-    public static IEnumerable<Person>? GetUpmContributors(this IPackageSearchMetadata packageSearchMetadata)
+    public static IEnumerable<Person> GetUpmContributors(this IPackageSearchMetadata packageSearchMetadata)
     {
         var otherAuthors = packageSearchMetadata.Authors.Split(',', ';', ' ');
         if (otherAuthors.Length <= 1)
-            return null;
+            return new List<Person>();
 
         return otherAuthors[1..].Select(author => new Person() { Name = author, });
     }

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -18,10 +18,13 @@ public static class PackageArchiveReaderExtension
     {
         return packageReader
             .GetFiles("lib")
-            .Select(f => Path.GetDirectoryName(f))
-            .Select(f => f?.Replace("lib/", string.Empty))
+            .Select(f => Path.GetDirectoryName(f) ?? string.Empty)
+            .Where(f => f != null)
+            .Select(f => f!)
+            .Select(f => f.Replace("lib/", string.Empty))
             .Distinct()
-            .OrderDescending();
+            .OrderDescending()
+            .ToList();
     }
 
     public static string SelectPreferredFramework(

--- a/NuGettier.Upm/TarGz/FileDictionaryExtension.cs
+++ b/NuGettier.Upm/TarGz/FileDictionaryExtension.cs
@@ -63,7 +63,7 @@ public static class FileDictionaryExtension
 
     public static void WriteToTar(this FileDictionary fileDictionary, string filePath)
     {
-        DirectoryInfo outputDirectory = new(Path.GetDirectoryName(filePath));
+        DirectoryInfo outputDirectory = new(Path.GetDirectoryName(filePath) ?? Environment.CurrentDirectory);
         if (!outputDirectory.Exists)
         {
             outputDirectory.Create();

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -22,11 +22,7 @@ public static partial class Program
     {
         get
         {
-            // Config.GlobalLocation = Path.Combine(Directory.GetCurrentDirectory(), "Content", "global.netconfig");
-            // Config.SystemLocation = Path.Combine(Directory.GetCurrentDirectory(), "Content", ".netconfig");
-            configurationRoot ??= new ConfigurationBuilder()
-                .AddDotNetConfig()
-                .Build();
+            configurationRoot ??= new ConfigurationBuilder().AddDotNetConfig().Build();
             return configurationRoot;
         }
     }


### PR DESCRIPTION
- refactor (NuGetter.Upm): fix cause of warnings in extension method PackageArchiveReader.GetAssemblyFrameworks()
- refactor (NuGetter.Upm): fix cause of warnings in extension method IPackageSearchMetadata.GetUpmContributors()
- refactor (NuGetter.Upm): fix warning in extension method FileDictionary.WriteToTar()
- refactor (NuGetter.Upm): make Upm.Context.DefaultPackageRule readonly
- refactor (NuGetter): remove unused commented code
