### PR TITLE
refactor: add option '--npmrc' to 'upm publish' command

### DIFF
--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -32,7 +32,7 @@ public partial class Context
         string? version,
         string? prereleaseSuffix,
         string? buildmetaSuffix,
-        string token,
+        string? token,
         bool dryRun,
         PackageAccessLevel packageAccessLevel,
         CancellationToken cancellationToken
@@ -59,8 +59,10 @@ public partial class Context
             var packageFile = $"{packageIdentifier}.tgz";
             await package.WriteToTarGzAsync(Path.Join(tempDir, packageFile));
 
-            using (var npmrcWriter = new StreamWriter(File.OpenWrite(Path.Join(tempDir, ".npmrc"))))
+            if (token != null)
             {
+                using var npmrcWriter = new StreamWriter(File.OpenWrite(Path.Join(tempDir, ".npmrc")));
+
                 // format is "//${schemeless_registry}/:_authToken=${token}"
                 npmrcWriter.WriteLine($"//{Target.SchemelessUri()}:_authToken={token}");
             }

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -33,6 +33,7 @@ public partial class Context
         string? prereleaseSuffix,
         string? buildmetaSuffix,
         string? token,
+        string? npmrc,
         bool dryRun,
         PackageAccessLevel packageAccessLevel,
         CancellationToken cancellationToken
@@ -65,6 +66,10 @@ public partial class Context
 
                 // format is "//${schemeless_registry}/:_authToken=${token}"
                 npmrcWriter.WriteLine($"//{Target.SchemelessUri()}:_authToken={token}");
+            }
+            else if (npmrc != null)
+            {
+                File.Copy(npmrc, Path.Join(tempDir, ".npmrc"));
             }
 
             try

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -25,6 +25,7 @@ public static partial class Program
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
             UpmToken,
+            UpmNpmrc,
             UpmDryRun,
             UpmPackageAccessLevel,
         }.WithHandler(CommandHandler.Create(UpmPublish));
@@ -39,6 +40,7 @@ public static partial class Program
         string? prereleaseSuffix,
         string? buildmetaSuffix,
         string? token,
+        string? npmrc,
         bool dryRun,
         Upm.PackageAccessLevel access,
         IConsole console,
@@ -60,6 +62,7 @@ public static partial class Program
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix,
             token: token,
+            npmrc: npmrc,
             dryRun: dryRun,
             packageAccessLevel: access,
             cancellationToken: cancellationToken

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -38,7 +38,7 @@ public static partial class Program
         Uri target,
         string? prereleaseSuffix,
         string? buildmetaSuffix,
-        string token,
+        string? token,
         bool dryRun,
         Upm.PackageAccessLevel access,
         IConsole console,

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -30,6 +30,12 @@ public static partial class Program
             IsRequired = false,
         };
 
+    private static Option<string> UpmNpmrc =
+        new(aliases: new string[] { "--npmrc", }, description: "path to existing .npmrc required to connect to NPM server")
+        {
+            IsRequired = false,
+        };
+
     private static Option<bool> UpmDryRun = new(aliases: new string[] { "--dry-run", "-n" }, description: "Dry run");
 
     private static Option<Upm.PackageAccessLevel> UpmPackageAccessLevel =

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -27,7 +27,7 @@ public static partial class Program
     private static Option<string> UpmToken =
         new(aliases: new string[] { "--token", }, description: "authentication token required to connect to NPM server")
         {
-            IsRequired = true,
+            IsRequired = false,
         };
 
     private static Option<bool> UpmDryRun = new(aliases: new string[] { "--dry-run", "-n" }, description: "Dry run");


### PR DESCRIPTION
- refactor (NuGettier.Upm): make option '--token' optional
- feature (NuGettier.Upm): add option '--npmrc'
- feature (NuGettier.Upm): add paramter npmrc to Upm.Context.PublishUpmPackage
- refactor (NuGettier): add option '--npmrc' to UpmPublish and forward to Upm.Context.PublishUpmPackage
