### PR TITLE
refactor (NuGettier.Upm): add parameters to fill PackageJson.Repository

### DIFF
--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -15,11 +15,19 @@ public partial class Context : Core.Context
     public Uri Target { get; protected set; }
     public IEnumerable<PackageRule> PackageRules { get; protected set; }
     public IDictionary<string, IPackageSearchMetadata> CachedMetadata { get; protected set; }
+    public string? Repository { get; protected set; }
 
-    public Context(IConfigurationRoot configuration, IEnumerable<Uri> sources, Uri target, IConsole console)
+    public Context(
+        IConfigurationRoot configuration,
+        IEnumerable<Uri> sources,
+        Uri target,
+        string? repository,
+        IConsole console
+    )
         : base(configuration, sources, console)
     {
         this.Target = target;
+        this.Repository = repository;
         this.CachedMetadata = new Dictionary<string, IPackageSearchMetadata>();
 
         this.PackageRules = Configuration
@@ -48,6 +56,7 @@ public partial class Context : Core.Context
         : base(other)
     {
         Target = other.Target;
+        Repository = other.Repository;
         PackageRules = other.PackageRules;
         CachedMetadata = other.CachedMetadata;
     }

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -16,18 +16,21 @@ public partial class Context : Core.Context
     public IEnumerable<PackageRule> PackageRules { get; protected set; }
     public IDictionary<string, IPackageSearchMetadata> CachedMetadata { get; protected set; }
     public string? Repository { get; protected set; }
+    public string? Directory { get; protected set; }
 
     public Context(
         IConfigurationRoot configuration,
         IEnumerable<Uri> sources,
         Uri target,
         string? repository,
+        string? directory,
         IConsole console
     )
         : base(configuration, sources, console)
     {
         this.Target = target;
         this.Repository = repository;
+        this.Directory = directory;
         this.CachedMetadata = new Dictionary<string, IPackageSearchMetadata>();
 
         this.PackageRules = Configuration
@@ -57,6 +60,7 @@ public partial class Context : Core.Context
     {
         Target = other.Target;
         Repository = other.Repository;
+        Directory = other.Directory;
         PackageRules = other.PackageRules;
         CachedMetadata = other.CachedMetadata;
     }

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -109,7 +109,7 @@ public partial class Context
                 Console.Error.WriteLine($"NPM: {e.Message}");
             }
 
-            Directory.Delete(tempDir, recursive: true);
+            System.IO.Directory.Delete(tempDir, recursive: true);
             return exitCode;
         }
     }

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -41,6 +41,12 @@ public partial class Context
         packageJson.PublishingConfiguration ??= new PublishingConfiguration();
         packageJson.PublishingConfiguration.Registry = Target.ToString();
 
+        // add repository/directory
+        if (!string.IsNullOrEmpty(Repository))
+            packageJson.Repository.Url = Repository;
+        if (!string.IsNullOrEmpty(Directory))
+            packageJson.Repository.Directory = Directory;
+
         return packageJson;
     }
 

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -99,9 +99,9 @@ public static class IPackageSearchMetadataExtension
     {
         return new Repository()
         {
-            RepoType = string.Empty,
-            Url = string.Empty,
-            Directory = string.Empty,
+            RepoType = @"git",
+            Url = packageSearchMetadata.ProjectUrl.ToString(),
+            Directory = packageSearchMetadata.Identity.Id.ToLowerInvariant(),
         };
     }
 

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -29,8 +29,8 @@ public static partial class Program
 
     static async Task<int> Main(string[] args)
     {
+        Console.WriteLine($"called with args: {string.Join(" ", args.Select(a => $"'{a}'"))}");
         Assert.NotNull(Configuration);
-
 
         var cmd = new RootCommand("Extended NuGet helper utility")
         { //

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -37,6 +37,7 @@ public static partial class Program
             TargetRegistryOption,
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
+            UpmRepositoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmInfo));
 
     private static async Task<int> UpmInfo(
@@ -49,6 +50,7 @@ public static partial class Program
         Uri target,
         string? prereleaseSuffix,
         string? buildmetaSuffix,
+        string? repository,
         IConsole console,
         CancellationToken cancellationToken
     )
@@ -58,6 +60,7 @@ public static partial class Program
             configuration: Configuration!,
             sources: sources,
             target: target,
+            repository: repository,
             console: console
         );
 

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -38,6 +38,7 @@ public static partial class Program
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
             UpmRepositoryUrlOption,
+            UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmInfo));
 
     private static async Task<int> UpmInfo(
@@ -51,6 +52,7 @@ public static partial class Program
         string? prereleaseSuffix,
         string? buildmetaSuffix,
         string? repository,
+        string? directory,
         IConsole console,
         CancellationToken cancellationToken
     )
@@ -61,6 +63,7 @@ public static partial class Program
             sources: sources,
             target: target,
             repository: repository,
+            directory: directory,
             console: console
         );
 

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -38,6 +38,7 @@ public static partial class Program
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
             UpmRepositoryUrlOption,
+            UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmPack));
 
     private static async Task<int> UpmPack(
@@ -51,6 +52,7 @@ public static partial class Program
         string? prereleaseSuffix,
         string? buildmetaSuffix,
         string? repository,
+        string? directory,
         IConsole console,
         CancellationToken cancellationToken
     )
@@ -61,6 +63,7 @@ public static partial class Program
             sources: sources,
             target: target,
             repository: repository,
+            directory: directory,
             console: console
         );
         var tuple = await context.PackUpmPackage(

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -37,6 +37,7 @@ public static partial class Program
             OutputDirectoryOption,
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
+            UpmRepositoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmPack));
 
     private static async Task<int> UpmPack(
@@ -49,6 +50,7 @@ public static partial class Program
         DirectoryInfo outputDirectory,
         string? prereleaseSuffix,
         string? buildmetaSuffix,
+        string? repository,
         IConsole console,
         CancellationToken cancellationToken
     )
@@ -58,6 +60,7 @@ public static partial class Program
             configuration: Configuration!,
             sources: sources,
             target: target,
+            repository: repository,
             console: console
         );
         var tuple = await context.PackUpmPackage(

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -26,7 +26,7 @@ public static partial class Program
             UpmBuildmetaSuffixOption,
             UpmTokenOption,
             UpmNpmrcOption,
-            UpmDryRun,
+            UpmDryRunOption,
             UpmPackageAccessLevel,
         }.WithHandler(CommandHandler.Create(UpmPublish));
 

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -24,7 +24,7 @@ public static partial class Program
             TargetRegistryOption,
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
-            UpmToken,
+            UpmTokenOption,
             UpmNpmrc,
             UpmDryRun,
             UpmPackageAccessLevel,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -24,6 +24,7 @@ public static partial class Program
             TargetRegistryOption,
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
+            UpmRepositoryUrlOption,
             UpmTokenOption,
             UpmNpmrcOption,
             UpmDryRunOption,
@@ -39,6 +40,7 @@ public static partial class Program
         Uri target,
         string? prereleaseSuffix,
         string? buildmetaSuffix,
+        string? repository,
         string? token,
         string? npmrc,
         bool dryRun,
@@ -52,6 +54,7 @@ public static partial class Program
             configuration: Configuration!,
             sources: sources,
             target: target,
+            repository: repository,
             console: console
         );
         var result = await context.PublishUpmPackage(

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -25,6 +25,7 @@ public static partial class Program
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
             UpmRepositoryUrlOption,
+            UpmDirectoryUrlOption,
             UpmTokenOption,
             UpmNpmrcOption,
             UpmDryRunOption,
@@ -41,6 +42,7 @@ public static partial class Program
         string? prereleaseSuffix,
         string? buildmetaSuffix,
         string? repository,
+        string? directory,
         string? token,
         string? npmrc,
         bool dryRun,
@@ -55,6 +57,7 @@ public static partial class Program
             sources: sources,
             target: target,
             repository: repository,
+            directory: directory,
             console: console
         );
         var result = await context.PublishUpmPackage(

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -25,7 +25,7 @@ public static partial class Program
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
             UpmTokenOption,
-            UpmNpmrc,
+            UpmNpmrcOption,
             UpmDryRun,
             UpmPackageAccessLevel,
         }.WithHandler(CommandHandler.Create(UpmPublish));

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -37,6 +37,7 @@ public static partial class Program
             OutputDirectoryOption,
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
+            UpmRepositoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmUnpack));
 
     private static async Task<int> UpmUnpack(
@@ -49,6 +50,7 @@ public static partial class Program
         DirectoryInfo outputDirectory,
         string? prereleaseSuffix,
         string? buildmetaSuffix,
+        string? repository,
         IConsole console,
         CancellationToken cancellationToken
     )
@@ -58,6 +60,7 @@ public static partial class Program
             configuration: Configuration!,
             sources: sources,
             target: target,
+            repository: repository,
             console: console
         );
         var tuple = await context.PackUpmPackage(

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -38,6 +38,7 @@ public static partial class Program
             UpmPrereleaseSuffixOption,
             UpmBuildmetaSuffixOption,
             UpmRepositoryUrlOption,
+            UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmUnpack));
 
     private static async Task<int> UpmUnpack(
@@ -51,6 +52,7 @@ public static partial class Program
         string? prereleaseSuffix,
         string? buildmetaSuffix,
         string? repository,
+        string? directory,
         IConsole console,
         CancellationToken cancellationToken
     )
@@ -61,6 +63,7 @@ public static partial class Program
             sources: sources,
             target: target,
             repository: repository,
+            directory: directory,
             console: console
         );
         var tuple = await context.PackUpmPackage(

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -39,7 +39,8 @@ public static partial class Program
             IsRequired = false,
         };
 
-    private static Option<bool> UpmDryRun = new(aliases: new string[] { "--dry-run", "-n" }, description: "Dry run");
+    private static Option<bool> UpmDryRunOption =
+        new(aliases: new string[] { "--dry-run", "-n" }, description: "Dry run");
 
     private static Option<Upm.PackageAccessLevel> UpmPackageAccessLevel =
         new(

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -48,6 +48,15 @@ public static partial class Program
             IsRequired = false,
         };
 
+    private static Option<string> UpmDirectoryUrlOption =
+        new(
+            aliases: new string[] { "--directory", },
+            description: "NPM package directory path, assigned to `{.repository.directory`}"
+        )
+        {
+            IsRequired = false,
+        };
+
     private static Option<bool> UpmDryRunOption =
         new(aliases: new string[] { "--dry-run", "-n" }, description: "Dry run");
 

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -39,6 +39,15 @@ public static partial class Program
             IsRequired = false,
         };
 
+    private static Option<Uri> UpmRepositoryUrlOption =
+        new(
+            aliases: new string[] { "--repository", },
+            description: "NPM package repository URL, assigned to `{.repository.url`}"
+        )
+        {
+            IsRequired = false,
+        };
+
     private static Option<bool> UpmDryRunOption =
         new(aliases: new string[] { "--dry-run", "-n" }, description: "Dry run");
 

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -30,8 +30,11 @@ public static partial class Program
             IsRequired = false,
         };
 
-    private static Option<string> UpmNpmrc =
-        new(aliases: new string[] { "--npmrc", }, description: "path to existing .npmrc required to connect to NPM server")
+    private static Option<string> UpmNpmrcOption =
+        new(
+            aliases: new string[] { "--npmrc", },
+            description: "path to existing .npmrc required to connect to NPM server"
+        )
         {
             IsRequired = false,
         };

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -24,7 +24,7 @@ public static partial class Program
             description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)"
         );
 
-    private static Option<string> UpmToken =
+    private static Option<string> UpmTokenOption =
         new(aliases: new string[] { "--token", }, description: "authentication token required to connect to NPM server")
         {
             IsRequired = false,


### PR DESCRIPTION
- refactor (NuGettier): print command line arguments at program start
- refactor (NuGettier): rename option variable UpmToken -> UpmTokenOption
- refactor (NuGettier): rename option variable UpmNpmrc -> UpmNpmrcOption
- refactor (NuGettier): rename option variable UpmDryRun -> UpmDryRunOption
- feature (NuGettier): add upm-sepcific option '--repository'
- feature (NuGettier.Upm): add repository URI to Upm.Context
- feature (NuGettier): add option '--repository' to 'upm info'
- feature (NuGettier): add option '--repository' to 'upm pack'
- feature (NuGettier): add option '--repository' to 'upm unpack'
- feature (NuGettier): add option '--repository' to 'upm publish'
- feature (NuGettier): add upm-specfic option '--directory'
- feature (NuGettier.Upm): add directory path to Upm.Context
- feature (NuGettier): add option '--directory' to 'upm info'
- feature (NuGettier): add option '--directory' to 'upm pack'
- feature (NuGettier): add option '--directory' to 'upm unpack'
- feature (NuGettier): add option '--directory' to 'upm publish'
- refactor (NuGettier.Upm): change IPackageSearchMetadata.GetUpmRepository() to return a properly filled Repository instance
- refactor (NuGettier.Upm): set PackageJson.Repository.Url/.Directory depending on Upm.Context.Repository/.Directory
