### PR TITLE
refactor (NuGettier.Upm): introduce configurable default .NET frameworks and compatible Unity versions

### DIFF
--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -16,6 +16,10 @@ public partial class Context : Core.Context
     public Uri Target { get; protected set; }
     public IEnumerable<PackageRule> PackageRules { get; protected set; }
     public IDictionary<string, string> SupportedFrameworks { get; protected set; }
+    public IEnumerable<string> Frameworks
+    {
+        get => SupportedFrameworks.Keys.OrderDescending().ToArray();
+    }
     public IDictionary<string, IPackageSearchMetadata> CachedMetadata { get; protected set; }
     public string? Repository { get; protected set; }
     public string? Directory { get; protected set; }

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -15,6 +15,7 @@ public partial class Context : Core.Context
     public string MinUnityVersion { get; protected set; }
     public Uri Target { get; protected set; }
     public IEnumerable<PackageRule> PackageRules { get; protected set; }
+    public IDictionary<string, string> SupportedFrameworks { get; protected set; }
     public IDictionary<string, IPackageSearchMetadata> CachedMetadata { get; protected set; }
     public string? Repository { get; protected set; }
     public string? Directory { get; protected set; }
@@ -56,6 +57,24 @@ public partial class Context : Core.Context
         {
             console.WriteLine($"{p}");
         }
+
+        this.SupportedFrameworks = new Dictionary<string, string>(DefaultSupportedFrameworks); //< cctor b/c modifications below
+        foreach (var frameworkSection in Configuration.GetSection(@"framework").GetChildren())
+        {
+            var unityVersion = frameworkSection.GetValue<string>("unity");
+            if (unityVersion != null)
+            {
+                console.WriteLine($"framework: {frameworkSection.Key} => {unityVersion}");
+                SupportedFrameworks[frameworkSection.Key] = unityVersion;
+            }
+
+            var ignoreFlag = frameworkSection.GetValue<bool>("ignore");
+            if (ignoreFlag)
+            {
+                console.WriteLine($"deleting framework: {frameworkSection.Key}");
+                SupportedFrameworks.Remove(frameworkSection.Key);
+            }
+        }
     }
 
     public Context(Context other)
@@ -67,5 +86,6 @@ public partial class Context : Core.Context
         Directory = other.Directory;
         PackageRules = other.PackageRules;
         CachedMetadata = other.CachedMetadata;
+        SupportedFrameworks = other.SupportedFrameworks;
     }
 }

--- a/NuGettier.Upm/Context/GetPackageInformation.cs
+++ b/NuGettier.Upm/Context/GetPackageInformation.cs
@@ -40,7 +40,11 @@ public partial class Context
             CachedMetadata[packageName] = packageSearchMetadata;
 
             var dependencies = packageSearchMetadata.DependencySets
-                .Where(dependencyGroup => Frameworks.Contains(dependencyGroup.TargetFramework.GetShortFolderName()))
+                .Where(
+                    dependencyGroup =>
+                        dependencyGroup.TargetFramework.GetShortFolderName()
+                        == packageSearchMetadata.GetUpmPreferredFramework(Frameworks)
+                )
                 .SelectMany(dependencyGroup => dependencyGroup.Packages)
                 .Distinct();
 

--- a/NuGettier.Upm/Context/GetPackageInformation.cs
+++ b/NuGettier.Upm/Context/GetPackageInformation.cs
@@ -40,10 +40,7 @@ public partial class Context
             CachedMetadata[packageName] = packageSearchMetadata;
 
             var dependencies = packageSearchMetadata.DependencySets
-                .Where(
-                    dependencyGroup =>
-                        Context.DefaultFrameworks.Contains(dependencyGroup.TargetFramework.GetShortFolderName())
-                )
+                .Where(dependencyGroup => Frameworks.Contains(dependencyGroup.TargetFramework.GetShortFolderName()))
                 .SelectMany(dependencyGroup => dependencyGroup.Packages)
                 .Distinct();
 

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -40,7 +40,7 @@ public partial class Context
         if (package == null)
             return null;
 
-        var packageJson = package.ToPackageJson();
+        var packageJson = package.ToPackageJson(SupportedFrameworks);
         Assert.NotNull(packageJson);
         if (packageJson == null)
             return null;

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -13,6 +13,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using Xunit;
 
 namespace NuGettier.Upm;
 
@@ -39,6 +40,11 @@ public partial class Context
         if (package == null)
             return null;
 
-        return PatchPackageJson(package.ToPackageJson());
+        var packageJson = package.ToPackageJson();
+        Assert.NotNull(packageJson);
+        if (packageJson == null)
+            return null;
+
+        return PatchPackageJson(packageJson);
     }
 }

--- a/NuGettier.Upm/Context/Globals.cs
+++ b/NuGettier.Upm/Context/Globals.cs
@@ -17,7 +17,10 @@ public partial class Context
         { "net462", "2017.4" },
     };
 
-    public static readonly string[] DefaultFrameworks = DefaultSupportedFrameworks.Keys.OrderDescending().ToArray();
+    public static string[] DefaultFrameworks
+    {
+        get => DefaultSupportedFrameworks.Keys.OrderDescending().ToArray();
+    }
 
     public static readonly PackageRule DefaultPackageRule =
         new(

--- a/NuGettier.Upm/Context/Globals.cs
+++ b/NuGettier.Upm/Context/Globals.cs
@@ -17,16 +17,7 @@ public partial class Context
         { "net462", "2017.4" },
     };
 
-    public static readonly string[] DefaultFrameworks = new[]
-    {
-        // by order of preference
-        "netstandard2.1",
-        "netstandard2.0",
-        "netstandard1.2",
-        "netstandard1.1",
-        "netstandard1.0",
-        "net462",
-    };
+    public static readonly string[] DefaultFrameworks = DefaultSupportedFrameworks.Keys.OrderDescending().ToArray();
 
     public static readonly PackageRule DefaultPackageRule =
         new(

--- a/NuGettier.Upm/Context/Globals.cs
+++ b/NuGettier.Upm/Context/Globals.cs
@@ -10,6 +10,13 @@ namespace NuGettier.Upm;
 
 public partial class Context
 {
+    public static readonly IDictionary<string, string> DefaultSupportedFrameworks = new Dictionary<string, string>()
+    {
+        { "netstandard2.1", "2021.3" },
+        { "netstandard2.0", "2018.1" },
+        { "net462", "2017.4" },
+    };
+
     public static readonly string[] DefaultFrameworks = new[]
     {
         // by order of preference

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -73,7 +73,7 @@ public partial class Context
         NuspecReader nuspecReader = await packageReader.GetNuspecReaderAsync(cancellationToken);
 
         var selectedFramework = packageReader.SelectPreferredFramework(
-            !string.IsNullOrEmpty(packageRule.Framework) ? new[] { packageRule.Framework } : DefaultFrameworks
+            !string.IsNullOrEmpty(packageRule.Framework) ? new[] { packageRule.Framework } : Frameworks
         );
         Console.WriteLine($"selected framework: {selectedFramework}");
 

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -22,6 +22,7 @@ public static class IPackageSearchMetadataExtension
             License = packageSearchMetadata.GetUpmLicense() ?? string.Empty,
             Description = packageSearchMetadata.GetUpmDescription(),
             DotNetFramework = packageSearchMetadata.GetUpmPreferredFramework(supportedUnityFrameworks.Keys),
+            MinUnityVersion = packageSearchMetadata.GetUpmPreferredUnityVersion(supportedUnityFrameworks),
             Homepage = packageSearchMetadata.GetUpmHomepage(),
             Keywords = packageSearchMetadata.GetUpmKeywords(),
             DisplayName = packageSearchMetadata.GetUpmDisplayName(),

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -21,6 +21,7 @@ public static class IPackageSearchMetadataExtension
             Version = packageSearchMetadata.GetUpmVersion(),
             License = packageSearchMetadata.GetUpmLicense() ?? string.Empty,
             Description = packageSearchMetadata.GetUpmDescription(),
+            DotNetFramework = packageSearchMetadata.GetUpmPreferredFramework(supportedUnityFrameworks.Keys),
             Homepage = packageSearchMetadata.GetUpmHomepage(),
             Keywords = packageSearchMetadata.GetUpmKeywords(),
             DisplayName = packageSearchMetadata.GetUpmDisplayName(),

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -137,4 +137,13 @@ public static class IPackageSearchMetadataExtension
             .ToHashSet();
         return ourFrameworks.Intersect(frameworks).OrderDescending().FirstOrDefault(frameworks.First());
     }
+
+    public static string GetUpmPreferredUnityVersion(
+        this IPackageSearchMetadata packageSearchMetadata,
+        IDictionary<string, string> unityFrameworks
+    )
+    {
+        var framework = packageSearchMetadata.GetUpmPreferredFramework(unityFrameworks.Keys);
+        return unityFrameworks[framework];
+    }
 }

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -126,4 +126,15 @@ public static class IPackageSearchMetadataExtension
                 .ToDictionary(d => d.Id, d => d.VersionRange.ToLegacyShortString())
         );
     }
+
+    public static string GetUpmPreferredFramework(
+        this IPackageSearchMetadata packageSearchMetadata,
+        IEnumerable<string> frameworks
+    )
+    {
+        var ourFrameworks = packageSearchMetadata.DependencySets
+            .Select(dependencyGroup => dependencyGroup.TargetFramework.GetShortFolderName())
+            .ToHashSet();
+        return ourFrameworks.Intersect(frameworks).OrderDescending().FirstOrDefault(frameworks.First());
+    }
 }

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -10,7 +10,10 @@ namespace NuGettier.Upm;
 
 public static class IPackageSearchMetadataExtension
 {
-    public static PackageJson ToPackageJson(this IPackageSearchMetadata packageSearchMetadata)
+    public static PackageJson ToPackageJson(
+        this IPackageSearchMetadata packageSearchMetadata,
+        IDictionary<string, string> supportedUnityFrameworks
+    )
     {
         return new PackageJson()
         {

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -25,7 +25,7 @@ public static class IPackageSearchMetadataExtension
             Contributors = packageSearchMetadata.GetUpmContributors(),
             Repository = packageSearchMetadata.GetUpmRepository(),
             PublishingConfiguration = packageSearchMetadata.GetUpmPublishingConfiguration(),
-            Dependencies = packageSearchMetadata.GetUpmDependencies(),
+            Dependencies = packageSearchMetadata.GetUpmDependencies(Context.DefaultFrameworks),
         };
     }
 
@@ -112,13 +112,12 @@ public static class IPackageSearchMetadataExtension
         return new PublishingConfiguration() { Registry = string.Empty, };
     }
 
-    public static IDictionary<string, string> GetUpmDependencies(this IPackageSearchMetadata packageSearchMetadata)
+    public static IDictionary<string, string> GetUpmDependencies(
+        this IPackageSearchMetadata packageSearchMetadata,
+        IEnumerable<string> frameworks
+    )
     {
-        var framework = packageSearchMetadata.DependencySets
-            .Select(dependencyGroup => dependencyGroup.TargetFramework.GetShortFolderName())
-            .Where(framework => Context.DefaultFrameworks.Contains(framework))
-            .FirstOrDefault(Context.DefaultFrameworks.First());
-
+        var framework = packageSearchMetadata.GetUpmPreferredFramework(frameworks);
         return new StringStringDictionary(
             packageSearchMetadata.DependencySets
                 .Where(dependencyGroup => dependencyGroup.TargetFramework.GetShortFolderName() == framework)

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -30,7 +30,7 @@ public static class IPackageSearchMetadataExtension
             Contributors = packageSearchMetadata.GetUpmContributors(),
             Repository = packageSearchMetadata.GetUpmRepository(),
             PublishingConfiguration = packageSearchMetadata.GetUpmPublishingConfiguration(),
-            Dependencies = packageSearchMetadata.GetUpmDependencies(Context.DefaultFrameworks),
+            Dependencies = packageSearchMetadata.GetUpmDependencies(supportedUnityFrameworks.Keys),
         };
     }
 

--- a/NuGettier.Upm/PackageJson/PackageJson.cs
+++ b/NuGettier.Upm/PackageJson/PackageJson.cs
@@ -25,6 +25,9 @@ public record class PackageJson
     [JsonPropertyName("unity")]
     public string MinUnityVersion { get; set; } = "2023.1";
 
+    [JsonPropertyName("dotnetframework")]
+    public string DotNetFramework { get; set; } = "netstandard2.1";
+
     [JsonPropertyName("homepage")]
     public string? Homepage { get; set; }
 


### PR DESCRIPTION
- feature (NuGettier.Upm): add LUT to match .NET framework against Unity version for max. compatibility
- refactor (NuGettier.Upm): create DRY DefaultFrameworks from DefaultSupportedFrameworks in correct order
- feature (NuGettier.Upm): create LUT to match .NET framework/Unity from .netconfig
- refactor (NuGettier.Upm): change DefaultFrameworks from static variable to static getter-only property
- feature (NuGettier.Upm): add getter-only property Upm.Context.Frameworks
- refactor (NuGettier.Upm): perform null check on generated PackageJson in Upm.Context.GetPackageJson()
- feature (NuGettier.Upm): implement IPackageSearchMetadata.GetUpmPreferredFramework() extension method
- feature (NuGettier.Upm): implement IPackageSearchMetadata.GetUpmPreferredUnityVersion() extension method
- refactor (NuGettier.Upm): adapt IPackageSearchMetadata.GetUpmDependencies() extension method to take available frameworks as input
- refactor (NuGettier.Upm): replace usage of static property DefaultFrameworks with instance property Frameworks
- feature (NuGettier.Upm): add PackageJson property DotNetFramework
- refactor (NuGettier.Upm): improve framework-based dependency selection to use preferred framework only
- refactor (NuGettier.Upm): add dictionary of supported .net-frameworks/unity-versions as parameter to IPackageSearchMetadata.ToPackageJson() extension method
- refactor (NuGettier.Upm): pass supported unity frameworks to IPackageSearchMetadata.ToPackageJson()
- refactor (NuGettier.Upm): set PackageJson.DotNetFramework from supported unity frameworks
- refactor (NuGettier.Upm): set PackageJson.MinUnityVersion from supported unity frameworks
- refactor (NuGettier.Upm): set PackageJson.Dependencies from supported unity frameworks
