### PR TITLE
fix (PatchPackageName): replace non-alphanumeric characters with '.'

### DIFF
--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -62,7 +62,11 @@ public partial class Context
             : Context.DefaultPackageRule.Name;
 
         var template = Handlebars.Compile(namingTemplate);
-        var result = template(CachedMetadata[packageName]).ToLowerInvariant().Replace(@" ", @"");
+        var result = Regex.Replace(
+            template(CachedMetadata[packageName]).ToLowerInvariant().Replace(@" ", ""),
+            @"\W",
+            @"."
+        );
         Console.WriteLine($"after: {result}");
         return result;
     }


### PR DESCRIPTION
reason: this fixes issues when multiple authors become part of the package name
