### PR TITLE
refactor (NuGettier.Upm): use lowercase package name to cache package metadata

### DIFF
--- a/NuGettier.Upm/Context/GetPackageInformation.cs
+++ b/NuGettier.Upm/Context/GetPackageInformation.cs
@@ -37,7 +37,7 @@ public partial class Context
         );
         if (packageSearchMetadata != null)
         {
-            CachedMetadata[packageName] = packageSearchMetadata;
+            CachedMetadata[packageName.ToLowerInvariant()] = packageSearchMetadata;
 
             var dependencies = packageSearchMetadata.DependencySets
                 .Where(
@@ -66,7 +66,7 @@ public partial class Context
                 foreach (var metadata in dependencyPackageSearchMetadata)
                 {
                     if (metadata != null)
-                        CachedMetadata[metadata.Identity.Id] = metadata;
+                        CachedMetadata[metadata.Identity.Id.ToLowerInvariant()] = metadata;
                 }
             }
         }

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -54,7 +54,8 @@ public partial class Context
     private string PatchPackageName(string packageName)
     {
         Console.WriteLine($"before: {packageName}");
-        Assert.NotNull(CachedMetadata[packageName]);
+        var metadata = CachedMetadata[packageName.ToLowerInvariant()];
+        Assert.NotNull(metadata);
 
         var packageRule = GetPackageRule(packageName);
         string namingTemplate = !string.IsNullOrEmpty(packageRule.Name)
@@ -63,7 +64,7 @@ public partial class Context
 
         var template = Handlebars.Compile(namingTemplate);
         var result = Regex.Replace(
-            template(CachedMetadata[packageName]).ToLowerInvariant().Replace(@" ", ""),
+            template(metadata).ToLowerInvariant().Replace(@" ", ""),
             @"\W",
             @"."
         );


### PR DESCRIPTION
- refactor (NuGettier.Upm): use lowercase package name to cache package metadata
- refactor (NuGettier.Upm): use lowercase package name to retrieve cached package metadata
