### PR TITLE
build: bump NuGet API dependencies to version 6.8.0

### DIFF
--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -28,11 +28,11 @@
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
-    <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.7.0"/>
+    <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.8.0"/>
     <PackageReference Include="SharpZipLib" Version="1.4.2"/>
     <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -22,11 +22,11 @@
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
-    <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.7.0"/>
+    <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.8.0"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="Xunit" Version="2.5.3"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -29,11 +29,11 @@
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
-    <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.7.0"/>
+    <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.8.0"/>
     <PackageReference Include="SharpZipLib" Version="1.4.2"/>
     <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -35,11 +35,11 @@
     <PackageReference Include="DotNetConfig" Version="1.0.6"/>
     <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
-    <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.7.0"/>
+    <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.8.0"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="Xunit" Version="2.5.3"/>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -23,11 +23,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="7.0.0"/>
-    <PackageReference Include="NuGet.Commands" Version="6.7.0"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.7.0"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.7.0"/>
+    <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.8.0"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.8.0"/>
     <PackageReference Include="Xunit" Version="2.5.3"/>
   </ItemGroup>
 


### PR DESCRIPTION
- build (NuGettier): bump NuGet API dependencies to version 6.8.0
- build (NuGettier.Core): bump NuGet API dependencies to version 6.8.0
- build (NuGettier.Upm): bump NuGet API dependencies to version 6.8.0
- build (NuGettier.Amalgamate): bump NuGet API dependencies to version 6.8.0
- build (Prototype): bump NuGet API dependencies to version 6.8.0
