### PR TITLE
refactor: use constants instead of strings for configuration section/value keys

### DIFF
--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -27,6 +27,7 @@ public partial class Context : IDisposable
     protected const string kPackageSection = @"package";
     protected const string kIgnoreKey = @"ignore";
     protected const string kNameKey = @"name";
+    protected const string kVersionKey = @"version";
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
@@ -122,7 +123,7 @@ public partial class Context : IDisposable
                     Id: packageSection.Key,
                     IsIgnored: packageSection.GetValue<bool>(kIgnoreKey),
                     Name: packageSection.GetValue<string>(kNameKey) ?? string.Empty,
-                    Version: packageSection.GetValue<string>("version") ?? string.Empty,
+                    Version: packageSection.GetValue<string>(kVersionKey) ?? string.Empty,
                     Framework: packageSection.GetValue<string>("framework") ?? string.Empty
                 );
             })

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -25,6 +25,7 @@ public partial class Context : IDisposable
     protected const string kPasswordKey = @"password";
     protected const string kProtocolKey = @"protocol";
     protected const string kPackageSection = @"package";
+    protected const string kIgnoreKey = @"ignore";
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
@@ -118,7 +119,7 @@ public partial class Context : IDisposable
                 console.WriteLine($"package key: {packageSection.Key}");
                 return new PackageRule(
                     Id: packageSection.Key,
-                    IsIgnored: packageSection.GetValue<bool>("ignore"),
+                    IsIgnored: packageSection.GetValue<bool>(kIgnoreKey),
                     Name: packageSection.GetValue<string>("name") ?? string.Empty,
                     Version: packageSection.GetValue<string>("version") ?? string.Empty,
                     Framework: packageSection.GetValue<string>("framework") ?? string.Empty

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -20,6 +20,8 @@ namespace NuGettier.Core;
 
 public partial class Context : IDisposable
 {
+    protected const string kSourceSection = @"source";
+
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
     public record class PackageRule(string Id, bool IsIgnored, string Name, string Version, string Framework);

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -22,6 +22,7 @@ public partial class Context : IDisposable
 {
     protected const string kSourceSection = @"source";
     protected const string kUsernameKey = @"username";
+    protected const string kPasswordKey = @"password";
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
@@ -67,10 +68,10 @@ public partial class Context : IDisposable
                     new Uri(
                         (
                             string.IsNullOrEmpty(sourceSection.GetValue<string>(kUsernameKey))
-                            && string.IsNullOrEmpty(sourceSection.GetValue<string>("password"))
+                            && string.IsNullOrEmpty(sourceSection.GetValue<string>(kPasswordKey))
                         )
                             ? $"{sourceSection.GetValue<string>("protocol") ?? "https"}://{sourceSection.Key}"
-                            : $"{sourceSection.GetValue<string>("protocol") ?? "https"}://{sourceSection[kUsernameKey]}:{sourceSection["password"]}@{sourceSection.Key}"
+                            : $"{sourceSection.GetValue<string>("protocol") ?? "https"}://{sourceSection[kUsernameKey]}:{sourceSection[kPasswordKey]}@{sourceSection.Key}"
                     )
             )
             .Concat(sources)

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -21,6 +21,7 @@ namespace NuGettier.Core;
 public partial class Context : IDisposable
 {
     protected const string kSourceSection = @"source";
+    protected const string kUsernameKey = @"username";
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
@@ -59,17 +60,17 @@ public partial class Context : IDisposable
         );
 
         Sources = Configuration
-            .GetSection(@"source")
+            .GetSection(kSourceSection)
             .GetChildren()
             .Select(
                 sourceSection =>
                     new Uri(
                         (
-                            string.IsNullOrEmpty(sourceSection.GetValue<string>("username"))
+                            string.IsNullOrEmpty(sourceSection.GetValue<string>(kUsernameKey))
                             && string.IsNullOrEmpty(sourceSection.GetValue<string>("password"))
                         )
                             ? $"{sourceSection.GetValue<string>("protocol") ?? "https"}://{sourceSection.Key}"
-                            : $"{sourceSection.GetValue<string>("protocol") ?? "https"}://{sourceSection["username"]}:{sourceSection["password"]}@{sourceSection.Key}"
+                            : $"{sourceSection.GetValue<string>("protocol") ?? "https"}://{sourceSection[kUsernameKey]}:{sourceSection["password"]}@{sourceSection.Key}"
                     )
             )
             .Concat(sources)

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -24,6 +24,7 @@ public partial class Context : IDisposable
     protected const string kUsernameKey = @"username";
     protected const string kPasswordKey = @"password";
     protected const string kProtocolKey = @"protocol";
+    protected const string kPackageSection = @"package";
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
@@ -110,7 +111,7 @@ public partial class Context : IDisposable
         });
 
         this.PackageRules = Configuration
-            .GetSection(@"package")
+            .GetSection(kPackageSection)
             .GetChildren()
             .Select(packageSection =>
             {

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -28,6 +28,7 @@ public partial class Context : IDisposable
     protected const string kIgnoreKey = @"ignore";
     protected const string kNameKey = @"name";
     protected const string kVersionKey = @"version";
+    protected const string kFrameworkKey = @"framework";
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
@@ -124,7 +125,7 @@ public partial class Context : IDisposable
                     IsIgnored: packageSection.GetValue<bool>(kIgnoreKey),
                     Name: packageSection.GetValue<string>(kNameKey) ?? string.Empty,
                     Version: packageSection.GetValue<string>(kVersionKey) ?? string.Empty,
-                    Framework: packageSection.GetValue<string>("framework") ?? string.Empty
+                    Framework: packageSection.GetValue<string>(kFrameworkKey) ?? string.Empty
                 );
             })
             .Distinct();

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -26,6 +26,7 @@ public partial class Context : IDisposable
     protected const string kProtocolKey = @"protocol";
     protected const string kPackageSection = @"package";
     protected const string kIgnoreKey = @"ignore";
+    protected const string kNameKey = @"name";
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
@@ -120,7 +121,7 @@ public partial class Context : IDisposable
                 return new PackageRule(
                     Id: packageSection.Key,
                     IsIgnored: packageSection.GetValue<bool>(kIgnoreKey),
-                    Name: packageSection.GetValue<string>("name") ?? string.Empty,
+                    Name: packageSection.GetValue<string>(kNameKey) ?? string.Empty,
                     Version: packageSection.GetValue<string>("version") ?? string.Empty,
                     Framework: packageSection.GetValue<string>("framework") ?? string.Empty
                 );

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -23,6 +23,7 @@ public partial class Context : IDisposable
     protected const string kSourceSection = @"source";
     protected const string kUsernameKey = @"username";
     protected const string kPasswordKey = @"password";
+    protected const string kProtocolKey = @"protocol";
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
@@ -70,8 +71,8 @@ public partial class Context : IDisposable
                             string.IsNullOrEmpty(sourceSection.GetValue<string>(kUsernameKey))
                             && string.IsNullOrEmpty(sourceSection.GetValue<string>(kPasswordKey))
                         )
-                            ? $"{sourceSection.GetValue<string>("protocol") ?? "https"}://{sourceSection.Key}"
-                            : $"{sourceSection.GetValue<string>("protocol") ?? "https"}://{sourceSection[kUsernameKey]}:{sourceSection[kPasswordKey]}@{sourceSection.Key}"
+                            ? $"{sourceSection.GetValue<string>(kProtocolKey) ?? "https"}://{sourceSection.Key}"
+                            : $"{sourceSection.GetValue<string>(kProtocolKey) ?? "https"}://{sourceSection[kUsernameKey]}:{sourceSection[kPasswordKey]}@{sourceSection.Key}"
                     )
             )
             .Concat(sources)

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -10,6 +10,8 @@ namespace NuGettier.Upm;
 
 public partial class Context : Core.Context
 {
+    protected const string kFrameworkSection = @"framework";
+
     public string MinUnityVersion { get; protected set; }
     public Uri Target { get; protected set; }
     public IDictionary<string, string> SupportedFrameworks { get; protected set; }
@@ -39,7 +41,7 @@ public partial class Context : Core.Context
         this.CachedMetadata = new Dictionary<string, IPackageSearchMetadata>();
 
         this.SupportedFrameworks = new Dictionary<string, string>(DefaultSupportedFrameworks); //< cctor b/c modifications below
-        foreach (var frameworkSection in Configuration.GetSection(@"framework").GetChildren())
+        foreach (var frameworkSection in Configuration.GetSection(kFrameworkSection).GetChildren())
         {
             var unityVersion = frameworkSection.GetValue<string>("unity");
             if (unityVersion != null)

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -48,7 +48,7 @@ public partial class Context : Core.Context
                 SupportedFrameworks[frameworkSection.Key] = unityVersion;
             }
 
-            var ignoreFlag = frameworkSection.GetValue<bool>("ignore");
+            var ignoreFlag = frameworkSection.GetValue<bool>(kIgnoreKey);
             if (ignoreFlag)
             {
                 console.WriteLine($"deleting framework: {frameworkSection.Key}");

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -11,6 +11,7 @@ namespace NuGettier.Upm;
 public partial class Context : Core.Context
 {
     protected const string kFrameworkSection = @"framework";
+    protected const string kUnityKey = @"unity";
 
     public string MinUnityVersion { get; protected set; }
     public Uri Target { get; protected set; }
@@ -43,7 +44,7 @@ public partial class Context : Core.Context
         this.SupportedFrameworks = new Dictionary<string, string>(DefaultSupportedFrameworks); //< cctor b/c modifications below
         foreach (var frameworkSection in Configuration.GetSection(kFrameworkSection).GetChildren())
         {
-            var unityVersion = frameworkSection.GetValue<string>("unity");
+            var unityVersion = frameworkSection.GetValue<string>(kUnityKey);
             if (unityVersion != null)
             {
                 console.WriteLine($"framework: {frameworkSection.Key} => {unityVersion}");


### PR DESCRIPTION
- refactor (NuGettier.Core): use constant instead of string for 'source' section key
- refactor (NuGettier.Core): use constant instead of string for 'username' value key
- refactor (NuGettier.Core): use constant instead of string for 'password' value key
- refactor (NuGettier.Core): use constant instead of string for 'protocol' value key
- refactor (NuGettier.Core): use constant instead of string for 'package' section key
- refactor (NuGettier.Core): use constant instead of string for 'ignore' value key
- refactor (NuGettier.Core): use constant instead of string for 'name' value key
- refactor (NuGettier.Core): use constant instead of string for 'version' value key
- refactor (NuGettier.Core): use constant instead of string for 'framework' value key
- refactor (NuGettier.Upm): use constant instead of string for 'framework' section key
- refactor (NuGettier.Upm): use constant instead of string for 'unity' value key
