### PR TITLE
refactor (NuGettier.Upm): inverse framework-unity relationship and select dependencies based on framework

### DIFF
--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -29,10 +29,6 @@ public partial class Context : Core.Context
     }
 
     public IDictionary<string, string> SupportedFrameworks { get; protected set; }
-    public IEnumerable<string> Frameworks
-    {
-        get => SupportedFrameworks.Keys.OrderDescending().ToArray();
-    }
     public IDictionary<string, IPackageSearchMetadata> CachedMetadata { get; protected set; }
     public string? Repository { get; protected set; }
     public string? Directory { get; protected set; }

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -28,7 +28,6 @@ public partial class Context : Core.Context
         protected set { NugetFramework = NuGetFramework.Parse(value); }
     }
 
-    public IDictionary<string, string> SupportedFrameworks { get; protected set; }
     public IDictionary<string, IPackageSearchMetadata> CachedMetadata { get; protected set; }
     public string? Repository { get; protected set; }
     public string? Directory { get; protected set; }
@@ -50,24 +49,6 @@ public partial class Context : Core.Context
         this.Directory = directory;
         this.CachedMetadata = new Dictionary<string, IPackageSearchMetadata>();
         this.Framework = GetFrameworkFromUnitySettings(minUnityVersion);
-
-        this.SupportedFrameworks = new Dictionary<string, string>(DefaultSupportedFrameworks); //< cctor b/c modifications below
-        foreach (var frameworkSection in Configuration.GetSection(kFrameworkSection).GetChildren())
-        {
-            var unityVersion = frameworkSection.GetValue<string>(kUnityKey);
-            if (unityVersion != null)
-            {
-                console.WriteLine($"framework: {frameworkSection.Key} => {unityVersion}");
-                SupportedFrameworks[frameworkSection.Key] = unityVersion;
-            }
-
-            var ignoreFlag = frameworkSection.GetValue<bool>(kIgnoreKey);
-            if (ignoreFlag)
-            {
-                console.WriteLine($"deleting framework: {frameworkSection.Key}");
-                SupportedFrameworks.Remove(frameworkSection.Key);
-            }
-        }
     }
 
     public Context(Context other)
@@ -79,8 +60,6 @@ public partial class Context : Core.Context
         Directory = other.Directory;
         CachedMetadata = other.CachedMetadata;
         NugetFramework = other.NugetFramework;
-
-        SupportedFrameworks = other.SupportedFrameworks;
     }
 
     internal string GetFrameworkFromUnitySettings(string minUnityVersion)

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.CommandLine;
 using NuGettier;
+using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.Protocol.Core.Types;
 using Microsoft.Extensions.Configuration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NuGettier.Upm;
 
@@ -15,6 +19,15 @@ public partial class Context : Core.Context
 
     public string MinUnityVersion { get; protected set; }
     public Uri Target { get; protected set; }
+
+    public NuGetFramework NugetFramework { get; protected set; }
+    public string Framework
+    {
+        get => NugetFramework.GetShortFolderName();
+        [MemberNotNull(nameof(NugetFramework))]
+        protected set { NugetFramework = NuGetFramework.Parse(value); }
+    }
+
     public IDictionary<string, string> SupportedFrameworks { get; protected set; }
     public IEnumerable<string> Frameworks
     {
@@ -40,6 +53,7 @@ public partial class Context : Core.Context
         this.Repository = repository;
         this.Directory = directory;
         this.CachedMetadata = new Dictionary<string, IPackageSearchMetadata>();
+        this.Framework = GetFrameworkFromUnitySettings(minUnityVersion);
 
         this.SupportedFrameworks = new Dictionary<string, string>(DefaultSupportedFrameworks); //< cctor b/c modifications below
         foreach (var frameworkSection in Configuration.GetSection(kFrameworkSection).GetChildren())
@@ -68,6 +82,8 @@ public partial class Context : Core.Context
         Repository = other.Repository;
         Directory = other.Directory;
         CachedMetadata = other.CachedMetadata;
+        NugetFramework = other.NugetFramework;
+
         SupportedFrameworks = other.SupportedFrameworks;
     }
 

--- a/NuGettier.Upm/Context/GetPackageInformation.cs
+++ b/NuGettier.Upm/Context/GetPackageInformation.cs
@@ -39,17 +39,16 @@ public partial class Context
         {
             CachedMetadata[packageName.ToLowerInvariant()] = packageSearchMetadata;
 
-            var dependencies = packageSearchMetadata.DependencySets
-                .Where(
-                    dependencyGroup =>
-                        dependencyGroup.TargetFramework.GetShortFolderName()
-                        == packageSearchMetadata.GetUpmPreferredFramework(Frameworks)
-                )
-                .SelectMany(dependencyGroup => dependencyGroup.Packages)
-                .Distinct();
+            var packageDependencyGroup = NuGetFrameworkUtility.GetNearest<PackageDependencyGroup>(
+                packageSearchMetadata.DependencySets,
+                NugetFramework
+            );
+
+            if (packageDependencyGroup is null)
+                return null;
 
             var dependencyPackageSearchMetadata = await Task.WhenAll(
-                dependencies.Select(
+                packageDependencyGroup.Packages.Select(
                     async dependency =>
                         await base.GetPackageInformation(
                             packageName: dependency.Id,

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -40,7 +40,7 @@ public partial class Context
         if (package == null)
             return null;
 
-        var packageJson = package.ToPackageJson(SupportedFrameworks);
+        var packageJson = package.ToPackageJson(NugetFramework, MinUnityVersion);
         Assert.NotNull(packageJson);
         if (packageJson == null)
             return null;

--- a/NuGettier.Upm/Context/Globals.cs
+++ b/NuGettier.Upm/Context/Globals.cs
@@ -10,13 +10,6 @@ namespace NuGettier.Upm;
 
 public partial class Context
 {
-    public static readonly IDictionary<string, string> DefaultSupportedFrameworks = new Dictionary<string, string>()
-    {
-        { "netstandard2.1", "2021.3" },
-        { "netstandard2.0", "2018.1" },
-        { "net462", "2017.4" },
-    };
-
     public static string[] DefaultFrameworks
     {
         get => DefaultSupportedFrameworks.Keys.OrderDescending().ToArray();

--- a/NuGettier.Upm/Context/Globals.cs
+++ b/NuGettier.Upm/Context/Globals.cs
@@ -10,11 +10,6 @@ namespace NuGettier.Upm;
 
 public partial class Context
 {
-    public static string[] DefaultFrameworks
-    {
-        get => DefaultSupportedFrameworks.Keys.OrderDescending().ToArray();
-    }
-
     public static readonly PackageRule DefaultPackageRule =
         new(
             Id: string.Empty,

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -72,12 +72,7 @@ public partial class Context
         using PackageArchiveReader packageReader = new(packageStream);
         NuspecReader nuspecReader = await packageReader.GetNuspecReaderAsync(cancellationToken);
 
-        var selectedFramework = packageReader.SelectPreferredFramework(
-            !string.IsNullOrEmpty(packageRule.Framework) ? new[] { packageRule.Framework } : Frameworks
-        );
-        Console.WriteLine($"selected framework: {selectedFramework}");
-
-        var files = packageReader.GetFrameworkFiles(selectedFramework);
+        var files = packageReader.GetFrameworkFiles(NugetFramework);
         files.AddRange(packageReader.GetAdditionalFiles(nuspecReader, renameOriginalMarkdownFiles: true));
 
         // create & add README

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -119,16 +119,18 @@ public static class IPackageSearchMetadataExtension
 
     public static IDictionary<string, string> GetUpmDependencies(
         this IPackageSearchMetadata packageSearchMetadata,
-        IEnumerable<string> frameworks
+        NuGetFramework nugetFramework
     )
     {
-        var framework = packageSearchMetadata.GetUpmPreferredFramework(frameworks);
-        return new StringStringDictionary(
-            packageSearchMetadata.DependencySets
-                .Where(dependencyGroup => dependencyGroup.TargetFramework.GetShortFolderName() == framework)
-                .SelectMany(dependencyGroup => dependencyGroup.Packages)
-                .ToDictionary(d => d.Id, d => d.VersionRange.ToLegacyShortString())
+        var packageDependencyGroup = NuGetFrameworkUtility.GetNearest<PackageDependencyGroup>(
+            packageSearchMetadata.DependencySets,
+            nugetFramework
         );
+
+        if (packageDependencyGroup is null)
+            return new Dictionary<string, string>();
+
+        return packageDependencyGroup.Packages.ToDictionary(d => d.Id, d => d.VersionRange.ToLegacyShortString());
     }
 
     public static string GetUpmPreferredFramework(

--- a/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/IPackageSearchMetadataExtension.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using System.Reflection;
+using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Protocol.Core.Types;
 using NuGet.Packaging.Licenses;
@@ -12,7 +14,8 @@ public static class IPackageSearchMetadataExtension
 {
     public static PackageJson ToPackageJson(
         this IPackageSearchMetadata packageSearchMetadata,
-        IDictionary<string, string> supportedUnityFrameworks
+        NuGetFramework nugetFramework,
+        string minUnityVersion
     )
     {
         return new PackageJson()
@@ -21,8 +24,8 @@ public static class IPackageSearchMetadataExtension
             Version = packageSearchMetadata.GetUpmVersion(),
             License = packageSearchMetadata.GetUpmLicense() ?? string.Empty,
             Description = packageSearchMetadata.GetUpmDescription(),
-            DotNetFramework = packageSearchMetadata.GetUpmPreferredFramework(supportedUnityFrameworks.Keys),
-            MinUnityVersion = packageSearchMetadata.GetUpmPreferredUnityVersion(supportedUnityFrameworks),
+            DotNetFramework = nugetFramework.GetShortFolderName(),
+            MinUnityVersion = minUnityVersion,
             Homepage = packageSearchMetadata.GetUpmHomepage(),
             Keywords = packageSearchMetadata.GetUpmKeywords(),
             DisplayName = packageSearchMetadata.GetUpmDisplayName(),
@@ -30,7 +33,7 @@ public static class IPackageSearchMetadataExtension
             Contributors = packageSearchMetadata.GetUpmContributors(),
             Repository = packageSearchMetadata.GetUpmRepository(),
             PublishingConfiguration = packageSearchMetadata.GetUpmPublishingConfiguration(),
-            Dependencies = packageSearchMetadata.GetUpmDependencies(supportedUnityFrameworks.Keys),
+            Dependencies = packageSearchMetadata.GetUpmDependencies(nugetFramework),
         };
     }
 


### PR DESCRIPTION
- refactor (NuGettier.Upm): change IPackageSearchMetadata.GetUpmDependencies() extension method to take NuGetFramework
- refactor (NuGettier.Upm): change IPackageSearchMetadata.ToPackageJson() extension method to take NuGetFramework and Unity version string
- feature (NuGettier.Upm): implement internal method Upm.Context.GetFrameworkFromUnitySettings()
- feature (NuGettier.Upm): add NuGetFramework and Framework properties to Upm.Context
- refactor (NuGettier.Upm): change PackageArchiveReader.GetFrameworkFiles() extension method to take NuGetFramework
- refactor (NuGettier.Upm): change Upm.Context.GetPackageInformation() override to select dependencies based on NuGetFramework
- refactor (NuGettier.Upm): remove readonly property Frameworks from Upm.Context
- refactor (NuGettier.Upm): remove property SupportedFrameworks from Upm.Context
- refactor (NuGettier.Upm): remove constant DefaultSupportedFrameworks
- refactor (NuGettier.Upm): remove constant DefaultFrameworks
