### PR TITLE
refactor: quick tidy-up pass

### DIFF
--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -114,7 +114,7 @@ public partial class Context : IDisposable
             return NuGet.Protocol.Core.Types.Repository.Factory.GetCoreV3(packageSource);
         });
 
-        this.PackageRules = Configuration
+        PackageRules = Configuration
             .GetSection(kPackageSection)
             .GetChildren()
             .Select(packageSection =>

--- a/NuGettier.Core/Extensions/StringExtension.cs
+++ b/NuGettier.Core/Extensions/StringExtension.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace NuGettier.Core;
+
+public static class StringExtension
+{
+    public static Regex WildcardToRegex(this string self)
+    {
+        return new Regex(self.Replace(@".", @"\.").Replace(@"%", @".?").Replace(@"*", @".*"), RegexOptions.Compiled);
+    }
+}

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -44,12 +44,13 @@ public partial class Context : Core.Context
     )
         : base(configuration, sources, console)
     {
-        this.MinUnityVersion = minUnityVersion;
-        this.Target = target;
-        this.Repository = repository;
-        this.Directory = directory;
-        this.CachedMetadata = new Dictionary<string, IPackageSearchMetadata>();
-        this.Framework = GetFrameworkFromUnitySettings(minUnityVersion);
+        MinUnityVersion = minUnityVersion;
+        Target = target;
+        Repository = repository;
+        Directory = directory;
+        CachedMetadata = new Dictionary<string, IPackageSearchMetadata>();
+        Framework = GetFrameworkFromUnitySettings(minUnityVersion);
+
     }
 
     public Context(Context other)

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -80,7 +80,6 @@ public partial class Context : Core.Context
             .Where(kvp => kvp.Key == minUnityVersion)
             .Select(kvp => kvp.Value)
             .FirstOrDefault();
-        Console.WriteLine($"framework (1st choice): {framework}");
         if (!string.IsNullOrEmpty(framework))
             return framework;
 
@@ -89,13 +88,11 @@ public partial class Context : Core.Context
             .Where(kvp => kvp.Key.WildcardToRegex().IsMatch(minUnityVersion))
             .Select(kvp => kvp.Value)
             .FirstOrDefault();
-        Console.WriteLine($"framework (2nd choice): {framework}");
         if (!string.IsNullOrEmpty(framework))
             return framework;
 
         // 3rd or last choice: default setting or hard-coded constant
         framework = Configuration.GetValue<string>(kFrameworkKey);
-        Console.WriteLine($"framework (3rd choice): {framework}");
         if (!string.IsNullOrEmpty(framework))
             return framework;
 

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.CommandLine;
 using NuGettier;
+using NuGettier.Core;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Protocol.Core.Types;
@@ -84,13 +85,7 @@ public partial class Context : Core.Context
 
         // 2nd choice: wildcard match from settings
         framework = unityToFramework
-            .Where(
-                kvp =>
-                    Regex.IsMatch(
-                        minUnityVersion,
-                        kvp.Key.Replace(@".", @"\.").Replace(@"%", @".?").Replace(@"*", @".*") //< wildcard to regex; TODO: string extension method
-                    )
-            )
+            .Where(kvp => kvp.Key.WildcardToRegex().IsMatch(minUnityVersion))
             .Select(kvp => kvp.Value)
             .FirstOrDefault();
         Console.WriteLine($"framework (2nd choice): {framework}");

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -63,11 +63,7 @@ public partial class Context
             : Context.DefaultPackageRule.Name;
 
         var template = Handlebars.Compile(namingTemplate);
-        var result = Regex.Replace(
-            template(metadata).ToLowerInvariant().Replace(@" ", ""),
-            @"\W",
-            @"."
-        );
+        var result = Regex.Replace(template(metadata).ToLowerInvariant().Replace(@" ", ""), @"\W", @".");
         Console.WriteLine($"after: {result}");
         return result;
     }


### PR DESCRIPTION
- feature (NuGettier.Core): implement string.WildcardToRegex() extension method
- refactor (NuGettier.Upm): use string.WildcardToRegex() extension method for 2nd choice unity version matching
- refactor (NuGettier.Upm): remove this. in Upm.Context.ctor
- refactor (NuGettier.Upm): remove logs from Upm.Context.GetFrameworkFromUnitySettings()
- refactor (NuGettier.Core): remove this. in Core.Context.ctor
- chore: apply csharpier formatting
