### PR TITLE
refactor (NuGettier): adapt command parameters to take packageId@version format

### DIFF
--- a/NuGettier.Core/Extensions/StringExtension.cs
+++ b/NuGettier.Core/Extensions/StringExtension.cs
@@ -9,4 +9,29 @@ public static class StringExtension
     {
         return new Regex(self.Replace(@".", @"\.").Replace(@"%", @".?").Replace(@"*", @".*"), RegexOptions.Compiled);
     }
+
+    public static void SplitPackageIdVersion(
+        this string self,
+        out string packageId,
+        out string? version,
+        out bool latest
+    )
+    {
+        var parts = self.Split(@"@");
+        if (parts.Length >= 1)
+            packageId = parts[0];
+        else
+            packageId = self;
+
+        version = null;
+        latest = false;
+
+        if (parts.Length >= 2)
+        {
+            latest = parts[1] == "latest";
+
+            if (!latest)
+                version = parts[1];
+        }
+    }
 }

--- a/NuGettier/Arguments.cs
+++ b/NuGettier/Arguments.cs
@@ -6,5 +6,7 @@ namespace NuGettier;
 public static partial class Program
 {
     private static Argument<string> PackageIdArgument = new("packageId", "complete and exact package id");
+    private static Argument<string> PackageIdVersionArgument =
+        new("packageIdVersion", "package.id[@version | @latest]");
     private static Argument<string> SearchTermArgument = new("searchTerm", "package id-ish or search term");
 }

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 using Xunit;
 
 namespace NuGettier;
@@ -26,21 +27,15 @@ public static partial class Program
     private static Command GetCommand =>
         new Command("get", "download the given NuPkg at the given version")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             SourceRepositoriesOption,
             OutputDirectoryOption,
-        }
-            .WithValidator(ValidateLatestOrVersion)
-            .WithHandler(CommandHandler.Create(Get));
+        }.WithHandler(CommandHandler.Create(Get));
 
     private static async Task<int> Get(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         IEnumerable<Uri> sources,
         DirectoryInfo outputDirectory,
         IConsole console,
@@ -48,6 +43,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         using var packageStream = await context.FetchPackage(
             packageId: packageId,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 using Xunit;
 
 namespace NuGettier;
@@ -25,21 +26,15 @@ public static partial class Program
     private static Command InfoCommand =>
         new Command("info", "retrieve information about a specific version of a given package")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             OutputJsonOption,
             SourceRepositoriesOption,
-        }
-            .WithValidator(ValidateLatestOrVersion)
-            .WithHandler(CommandHandler.Create(Info));
+        }.WithHandler(CommandHandler.Create(Info));
 
     private static async Task<int> Info(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         bool json,
         IEnumerable<Uri> sources,
         IConsole console,
@@ -47,6 +42,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var package = await context.GetPackageInformation(
             packageId: packageId,

--- a/NuGettier/CoreActions/ListDependencies.cs
+++ b/NuGettier/CoreActions/ListDependencies.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 using Xunit;
 
 namespace NuGettier;
@@ -25,21 +26,15 @@ public static partial class Program
     private static Command ListDependenciesCommand =>
         new Command("deps", "retrieve information about a specific version of a given package")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             OutputJsonOption,
             SourceRepositoriesOption,
-        }
-            .WithValidator(ValidateLatestOrVersion)
-            .WithHandler(CommandHandler.Create(ListDependencies));
+        }.WithHandler(CommandHandler.Create(ListDependencies));
 
     private static async Task<int> ListDependencies(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         bool json,
         IEnumerable<Uri> sources,
         IConsole console,
@@ -47,6 +42,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var packages = await context.GetPackageDependencies(
             packageId: packageId,

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -28,11 +29,9 @@ public static partial class Program
     private static Command UpmInfoCommand =>
         new Command("info", "preview Unity package informations for the given NuPkg at the given version")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             OutputJsonOption,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             SourceRepositoriesOption,
             TargetRegistryOption,
             UpmUnityVersionOption,
@@ -43,11 +42,9 @@ public static partial class Program
         }.WithHandler(CommandHandler.Create(UpmInfo));
 
     private static async Task<int> UpmInfo(
-        string packageId,
+        string packageIdVersion,
         bool json,
         bool preRelease,
-        bool latest,
-        string version,
         IEnumerable<Uri> sources,
         Uri target,
         string unity,
@@ -60,6 +57,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -28,10 +29,8 @@ public static partial class Program
     private static Command UpmPackCommand =>
         new Command("pack", "repack the given NuPkg at the given version as Unity package")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             SourceRepositoriesOption,
             TargetRegistryOption,
             OutputDirectoryOption,
@@ -43,10 +42,8 @@ public static partial class Program
         }.WithHandler(CommandHandler.Create(UpmPack));
 
     private static async Task<int> UpmPack(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string version,
         IEnumerable<Uri> sources,
         Uri target,
         DirectoryInfo outputDirectory,
@@ -60,6 +57,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -7,6 +7,7 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
+using NuGettier.Core;
 using Xunit;
 
 namespace NuGettier;
@@ -16,10 +17,8 @@ public static partial class Program
     private static Command UpmPublishCommand =>
         new Command("publish", "repack the given NuPkg at the given version as Unity package and publish")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             SourceRepositoriesOption,
             TargetRegistryOption,
             UpmUnityVersionOption,
@@ -34,10 +33,8 @@ public static partial class Program
         }.WithHandler(CommandHandler.Create(UpmPublish));
 
     private static async Task<int> UpmPublish(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string version,
         IEnumerable<Uri> sources,
         Uri target,
         string unity,
@@ -54,6 +51,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -28,10 +29,8 @@ public static partial class Program
     private static Command UpmUnpackCommand =>
         new Command("unpack", "same as `upm pack`, but writing the unpacked files to the output directory")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             SourceRepositoriesOption,
             TargetRegistryOption,
             OutputDirectoryOption,
@@ -43,10 +42,8 @@ public static partial class Program
         }.WithHandler(CommandHandler.Create(UpmUnpack));
 
     private static async Task<int> UpmUnpack(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string version,
         IEnumerable<Uri> sources,
         Uri target,
         DirectoryInfo outputDirectory,
@@ -60,6 +57,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -28,11 +29,9 @@ public static partial class Program
     private static Command AmalgamateInfoCommand =>
         new Command("info", "preview Unity package informations for the given NuPkg at the given version")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             OutputJsonOption,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             SourceRepositoriesOption,
             TargetRegistryOption,
             UpmUnityVersionOption,
@@ -43,11 +42,9 @@ public static partial class Program
         }.WithHandler(CommandHandler.Create(AmalgamateInfo));
 
     private static async Task<int> AmalgamateInfo(
-        string packageId,
+        string packageIdVersion,
         bool json,
         bool preRelease,
-        bool latest,
-        string version,
         IEnumerable<Uri> sources,
         Uri target,
         string unity,
@@ -60,6 +57,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -28,10 +29,8 @@ public static partial class Program
     private static Command AmalgamatePackCommand =>
         new Command("pack", "repack the given NuPkg at the given version as Unity package")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             SourceRepositoriesOption,
             TargetRegistryOption,
             OutputDirectoryOption,
@@ -43,10 +42,8 @@ public static partial class Program
         }.WithHandler(CommandHandler.Create(AmalgamatePack));
 
     private static async Task<int> AmalgamatePack(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string version,
         IEnumerable<Uri> sources,
         Uri target,
         DirectoryInfo outputDirectory,
@@ -60,6 +57,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -7,6 +7,7 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
+using NuGettier.Core;
 using Xunit;
 
 namespace NuGettier;
@@ -16,10 +17,8 @@ public static partial class Program
     private static Command AmalgamatePublishCommand =>
         new Command("publish", "repack the given NuPkg at the given version as Unity package and publish")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             SourceRepositoriesOption,
             TargetRegistryOption,
             UpmUnityVersionOption,
@@ -34,10 +33,8 @@ public static partial class Program
         }.WithHandler(CommandHandler.Create(AmalgamatePublish));
 
     private static async Task<int> AmalgamatePublish(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string version,
         IEnumerable<Uri> sources,
         Uri target,
         string unity,
@@ -54,6 +51,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
             sources: sources,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -28,10 +29,8 @@ public static partial class Program
     private static Command AmalgamateUnpackCommand =>
         new Command("unpack", "same as `upm pack`, but writing the unpacked files to the output directory")
         {
-            PackageIdArgument,
+            PackageIdVersionArgument,
             IncludePrereleaseOption,
-            RetrieveLatestOption,
-            SpecificVersionOption,
             SourceRepositoriesOption,
             TargetRegistryOption,
             OutputDirectoryOption,
@@ -43,10 +42,8 @@ public static partial class Program
         }.WithHandler(CommandHandler.Create(AmalgamateUnpack));
 
     private static async Task<int> AmalgamateUnpack(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string version,
         IEnumerable<Uri> sources,
         Uri target,
         DirectoryInfo outputDirectory,
@@ -60,6 +57,7 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
             sources: sources,


### PR DESCRIPTION
- feature (NuGettier): add Argument 'PackageIdVersionArgument'
- feature (NuGettier.Core): implement string.SplitPackageIdVersion() extension method
- refactor (NuGettier): adapt 'Get' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'Info' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'ListDependencies' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'UpmInfo' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'UpmPack' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'UpmUnpack' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'UpmPublish' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'AmalgamateInfo' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'AmalgamatePack' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'AmalgamateUnpack' command parameters to take packageId@version format
- refactor (NuGettier): adapt 'AmalgamatePublish' command parameters to take packageId@version format
