### PR TITLE
refactor: adapt Context methods to take packageIdVersion argument

### DIFF
--- a/NuGettier.Amalgamate/Context/GetPackageJson.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageJson.cs
@@ -23,18 +23,14 @@ namespace NuGettier.Amalgamate;
 public partial class Context
 {
     public override async Task<Upm.PackageJson?> GetPackageJson(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         CancellationToken cancellationToken
     )
     {
         var packageJsonOrig = await base.GetPackageJson(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier.Amalgamate/Context/PackUpmPackage.cs
+++ b/NuGettier.Amalgamate/Context/PackUpmPackage.cs
@@ -27,20 +27,16 @@ using NuRepository = NuGet.Protocol.Core.Types.Repository;
 public partial class Context
 {
     public override async Task<Tuple<string, FileDictionary>?> PackUpmPackage(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         string? prereleaseSuffix,
         string? buildmetaSuffix,
         CancellationToken cancellationToken
     )
     {
         return await base.PackUpmPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken

--- a/NuGettier.Core/Context/FetchPackage.cs
+++ b/NuGettier.Core/Context/FetchPackage.cs
@@ -21,13 +21,12 @@ namespace NuGettier.Core;
 public partial class Context
 {
     public virtual async Task<MemoryStream?> FetchPackage(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         CancellationToken cancellationToken
     )
     {
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         IEnumerable<FindPackageByIdResource> resources = await Repositories.GetResourceAsync<FindPackageByIdResource>(
             cancellationToken
         );

--- a/NuGettier.Core/Context/GetPackageDependencies.cs
+++ b/NuGettier.Core/Context/GetPackageDependencies.cs
@@ -28,11 +28,10 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        var packageIdVersion = $"{packageId}@{(version ?? "latest")}";
         var package = await GetPackageInformation(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
 
@@ -53,10 +52,8 @@ public partial class Context
                     .Select(
                         async (d) =>
                             await GetPackageInformation(
-                                packageId: d.Key,
+                                packageIdVersion: $"{d.Key}@{d.Value}",
                                 preRelease: preRelease,
-                                latest: false,
-                                version: d.Value,
                                 cancellationToken: cancellationToken
                             )
                     )

--- a/NuGettier.Core/Context/GetPackageDependencies.cs
+++ b/NuGettier.Core/Context/GetPackageDependencies.cs
@@ -21,14 +21,11 @@ namespace NuGettier.Core;
 public partial class Context
 {
     public virtual async Task<IEnumerable<IPackageSearchMetadata>?> GetPackageDependencies(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         CancellationToken cancellationToken
     )
     {
-        var packageIdVersion = $"{packageId}@{(version ?? "latest")}";
         var package = await GetPackageInformation(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier.Core/Context/GetPackageInformation.cs
+++ b/NuGettier.Core/Context/GetPackageInformation.cs
@@ -21,13 +21,12 @@ namespace NuGettier.Core;
 public partial class Context
 {
     public virtual async Task<IPackageSearchMetadata?> GetPackageInformation(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         CancellationToken cancellationToken
     )
     {
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         var packages = await GetPackageVersions(
             packageId: packageId,
             preRelease: preRelease,

--- a/NuGettier.Upm/Context/GetPackageInformation.cs
+++ b/NuGettier.Upm/Context/GetPackageInformation.cs
@@ -13,6 +13,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using NuGettier.Core;
 
 namespace NuGettier.Upm;
 
@@ -21,18 +22,15 @@ namespace NuGettier.Upm;
 public partial class Context
 {
     public override async Task<IPackageSearchMetadata?> GetPackageInformation(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         CancellationToken cancellationToken
     )
     {
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         var packageSearchMetadata = await base.GetPackageInformation(
-            packageId,
+            packageIdVersion,
             preRelease,
-            latest,
-            version,
             cancellationToken
         );
         if (packageSearchMetadata != null)
@@ -51,10 +49,8 @@ public partial class Context
                 packageDependencyGroup.Packages.Select(
                     async dependency =>
                         await base.GetPackageInformation(
-                            packageId: dependency.Id,
+                            packageIdVersion: $"{dependency.Id}@{dependency.VersionRange.ToLegacyShortString()}",
                             preRelease: true,
-                            latest: false,
-                            version: dependency.VersionRange.ToLegacyShortString(),
                             cancellationToken: cancellationToken
                         )
                 )

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -29,11 +29,10 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        var packageIdVersion = $"{packageId}@{(version ?? "latest")}";
         var package = await GetPackageInformation(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -22,14 +22,11 @@ namespace NuGettier.Upm;
 public partial class Context
 {
     public virtual async Task<PackageJson?> GetPackageJson(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         CancellationToken cancellationToken
     )
     {
-        var packageIdVersion = $"{packageId}@{(version ?? "latest")}";
         var package = await GetPackageInformation(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -59,11 +59,10 @@ public partial class Context
         Assert.NotNull(packageRule);
 
         // fetch package contents for NuGet
+        var packageIdVersion = $"{packageId}@{(version ?? "latest")}";
         using var packageStream = await FetchPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
         if (packageStream == null)

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -37,11 +37,10 @@ public partial class Context
     )
     {
         // build package.json from package information
+        var packageIdVersion = $"{packageId}@{(version ?? "latest")}";
         var packageJson = await GetPackageJson(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
 
@@ -59,7 +58,6 @@ public partial class Context
         Assert.NotNull(packageRule);
 
         // fetch package contents for NuGet
-        var packageIdVersion = $"{packageId}@{(version ?? "latest")}";
         using var packageStream = await FetchPackage(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -26,10 +26,8 @@ namespace NuGettier.Upm;
 public partial class Context
 {
     public virtual async Task<int> PublishUpmPackage(
-        string packageId,
+        string packageIdVersion,
         bool preRelease,
-        bool latest,
-        string? version,
         string? prereleaseSuffix,
         string? buildmetaSuffix,
         string? token,
@@ -39,7 +37,6 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
-        var packageIdVersion = $"{packageId}@{(version ?? "latest")}";
         var tuple = await PackUpmPackage(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -39,11 +39,10 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        var packageIdVersion = $"{packageId}@{(version ?? "latest")}";
         var tuple = await PackUpmPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -43,13 +43,10 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         using var packageStream = await context.FetchPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
 
@@ -139,7 +136,7 @@ public static partial class Program
 
             using (
                 FileStream fileStream = new FileStream(
-                    $"{Path.Join(outputDirectory.FullName, $"{packageId}-{nuspecReader.GetVersion()}.nupkg")}",
+                    $"{Path.Join(outputDirectory.FullName, $"{nuspecReader.GetId()}-{nuspecReader.GetVersion()}.nupkg")}",
                     FileMode.Create,
                     FileAccess.Write
                 )

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -16,7 +16,6 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
-using NuGettier.Core;
 using Xunit;
 
 namespace NuGettier;
@@ -42,13 +41,10 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var package = await context.GetPackageInformation(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier/CoreActions/ListDependencies.cs
+++ b/NuGettier/CoreActions/ListDependencies.cs
@@ -42,13 +42,10 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
         var packages = await context.GetPackageDependencies(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -17,7 +17,6 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
-using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -57,7 +56,6 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,
@@ -69,10 +67,8 @@ public static partial class Program
         );
 
         var packageJson = await context.GetPackageJson(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -57,7 +57,6 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,
@@ -68,10 +67,8 @@ public static partial class Program
             console: console
         );
         var tuple = await context.PackUpmPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -7,7 +7,6 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
-using NuGettier.Core;
 using Xunit;
 
 namespace NuGettier;
@@ -51,7 +50,6 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,
@@ -62,10 +60,8 @@ public static partial class Program
             console: console
         );
         var result = await context.PublishUpmPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix,
             token: token,

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -57,7 +57,6 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Upm.Context(
             configuration: Configuration!,
             sources: sources,
@@ -68,10 +67,8 @@ public static partial class Program
             console: console
         );
         var tuple = await context.PackUpmPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -17,7 +17,6 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
-using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -57,7 +56,6 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
             sources: sources,
@@ -69,10 +67,8 @@ public static partial class Program
         );
 
         var packageJson = await context.GetPackageJson(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -17,7 +17,6 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
-using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -57,7 +56,6 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
             sources: sources,
@@ -68,10 +66,8 @@ public static partial class Program
             console: console
         );
         var tuple = await context.PackUpmPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -7,7 +7,6 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
-using NuGettier.Core;
 using Xunit;
 
 namespace NuGettier;
@@ -51,7 +50,6 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
             sources: sources,
@@ -62,10 +60,8 @@ public static partial class Program
             console: console
         );
         var result = await context.PublishUpmPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix,
             token: token,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -17,7 +17,6 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
-using NuGettier.Core;
 using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
@@ -57,7 +56,6 @@ public static partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
             sources: sources,
@@ -68,10 +66,8 @@ public static partial class Program
             console: console
         );
         var tuple = await context.PackUpmPackage(
-            packageId: packageId,
+            packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            latest: latest,
-            version: version,
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken


### PR DESCRIPTION
- refactor (NuGettier.Core): adapt Core.Context.FetchPackage() to take packageIdVersion argument
- refactor (NuGettier.Core): adapt Core.Context.GetPackageInformation() to take packageIdVersion argument
- refactor (NuGettier.Core): adapt Core.Context.GetPackageDependencies() to take packageIdVersion argument
- refactor (NuGettier.Upm): adapt Upm.Context.GetPackageJson() to take packageIdVersion argument
- refactor (NuGettier.Upm): adapt Upm.Context.PackUpmPackage() to take packageIdVersion argument
- refactor (NuGettier.Upm): adapt Upm.Context.PublishUpmPackage() to take packageIdVersion argument
