### PR TITLE
refactor (NuGettier.Upm): adapt PackageArchiveReader.GetXXXFiles() extension methods to return files with PackageId as root folder

### DIFF
--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -69,7 +69,7 @@ public partial class Context
         NuspecReader nuspecReader = await packageReader.GetNuspecReaderAsync(cancellationToken);
 
         var files = packageReader.GetFrameworkFiles(NugetFramework);
-        files.AddRange(packageReader.GetAdditionalFiles(nuspecReader, renameOriginalMarkdownFiles: true));
+        files.AddRange(packageReader.GetAdditionalFiles(nuspecReader));
 
         // create & add README
         if (!files.ContainsKey(@"README.md"))

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -69,8 +69,7 @@ public static class PackageArchiveReaderExtension
 
     public static TarGz.FileDictionary GetAdditionalFiles(
         this PackageArchiveReader packageReader,
-        NuspecReader nuspecReader,
-        bool renameOriginalMarkdownFiles
+        NuspecReader nuspecReader
     )
     {
         List<string> additionalFiles =

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -60,7 +60,10 @@ public static class PackageArchiveReaderExtension
             return new TarGz.FileDictionary();
 
         return new TarGz.FileDictionary(
-            frameworkSpecificGroup.Items.ToDictionary(f => f, f => packageReader.GetBytes(f))
+            frameworkSpecificGroup.Items.ToDictionary(
+                f => $"{packageReader.NuspecReader.GetId()}/{f}", //< explicitly forward slashes '/' for paths
+                f => packageReader.GetBytes(f)
+            )
         );
     }
 

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -88,14 +88,9 @@ public static class PackageArchiveReaderExtension
             packageReader
                 .GetFiles()
                 .Where(f => additionalFiles.Contains(f))
-                .Select(
-                    f =>
-                        new KeyValuePair<string, byte[]>(
-                            renameOriginalMarkdownFiles && Path.GetExtension(f) == ".md"
-                                ? $"{Path.GetFileNameWithoutExtension(f)}.orig{Path.GetExtension(f)}"
-                                : f,
-                            packageReader.GetBytes(f)
-                        )
+                .ToDictionary(
+                    f => $"{packageReader.NuspecReader.GetId()}/{f}", //< explicitly forward slashes '/' for paths
+                    f => packageReader.GetBytes(f)
                 )
         );
     }


### PR DESCRIPTION
- refactor (NuGettier.Upm): adapt PackageArchiveReader.GetFrameworkFiles() returns files with PackageId as root folder
- refactor (NuGettier.Upm): adapt PackageArchiveReader.GetAdditionalFiles() returns files with PackageId as root folder
- refactor (NuGettier.Upm): remove argument 'renameOriginalMarkdownFiles' from PackageArchiveReader.GetAdditionalFiles()
