### PR TITLE
refactor: use PackageArchiveReader.NuspecReader directly

### DIFF
--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -66,7 +66,7 @@ public partial class Context
             return null;
 
         using PackageArchiveReader packageReader = new(packageStream);
-        NuspecReader nuspecReader = await packageReader.GetNuspecReaderAsync(cancellationToken);
+        NuspecReader nuspecReader = packageReader.NuspecReader;
 
         var files = packageReader.GetFrameworkFiles(NugetFramework);
         files.AddRange(packageReader.GetAdditionalFiles(nuspecReader));

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -83,7 +83,7 @@ public partial class Context
         if (!files.ContainsKey(@"LICENSE.md"))
         {
             var license = packageJson.GenerateLicense(
-                originalLicense: packageReader.GetLicense(nuspecReader),
+                originalLicense: packageReader.GetLicense(),
                 copyright: nuspecReader.GetCopyright(),
                 copyrightHolder: nuspecReader.GetOwners()
             );

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -74,7 +74,7 @@ public partial class Context
         // create & add README
         if (!files.ContainsKey(@"README.md"))
         {
-            var readme = packageJson.GenerateReadme(originalReadme: packageReader.GetReadme(nuspecReader));
+            var readme = packageJson.GenerateReadme(originalReadme: packageReader.GetReadme());
             files.Add(@"README.md", readme);
             Console.WriteLine($"--- README\n{Encoding.Default.GetString(files[@"README.md"])}\n---");
         }

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -66,7 +66,6 @@ public partial class Context
             return null;
 
         using PackageArchiveReader packageReader = new(packageStream);
-        NuspecReader nuspecReader = packageReader.NuspecReader;
 
         var files = packageReader.GetFrameworkFiles(NugetFramework);
         files.AddRange(packageReader.GetAdditionalFiles());
@@ -84,8 +83,8 @@ public partial class Context
         {
             var license = packageJson.GenerateLicense(
                 originalLicense: packageReader.GetLicense(),
-                copyright: nuspecReader.GetCopyright(),
-                copyrightHolder: nuspecReader.GetOwners()
+                copyright: packageReader.NuspecReader.GetCopyright(),
+                copyrightHolder: packageReader.NuspecReader.GetOwners()
             );
             files.Add(@"LICENSE.md", license);
             Console.WriteLine($"--- LICENSE\n{Encoding.Default.GetString(files[@"LICENSE.md"])}\n---");
@@ -94,7 +93,7 @@ public partial class Context
         // create & add CHANGELOG
         if (!files.ContainsKey(@"CHANGELOG.md"))
         {
-            var changelog = packageJson.GenerateChangelog(nuspecReader.GetReleaseNotes());
+            var changelog = packageJson.GenerateChangelog(packageReader.NuspecReader.GetReleaseNotes());
             files.Add(@"CHANGELOG.md", changelog);
             Console.WriteLine($"--- CHANGELOG\n{Encoding.Default.GetString(files[@"CHANGELOG.md"])}\n---");
         }

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -69,7 +69,7 @@ public partial class Context
         NuspecReader nuspecReader = packageReader.NuspecReader;
 
         var files = packageReader.GetFrameworkFiles(NugetFramework);
-        files.AddRange(packageReader.GetAdditionalFiles(nuspecReader));
+        files.AddRange(packageReader.GetAdditionalFiles());
 
         // create & add README
         if (!files.ContainsKey(@"README.md"))

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -120,7 +120,7 @@ public static class PackageArchiveReaderExtension
         return null;
     }
 
-    public static string GetLicense(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
+    public static string GetLicense(this PackageArchiveReader packageReader)
     {
         byte[]? data = packageReader.GetLicenseFile();
         if (data == null || data.Length == 0)

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -99,7 +99,7 @@ public static class PackageArchiveReaderExtension
         return packageReader.GetBytes(packageReader.NuspecReader.GetReadme());
     }
 
-    public static string GetReadme(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
+    public static string GetReadme(this PackageArchiveReader packageReader)
     {
         byte[]? data = packageReader.GetReadmeFile();
         if (data == null || data.Length == 0)

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -113,7 +113,7 @@ public static class PackageArchiveReaderExtension
         var packageFiles = packageReader.GetFiles();
         foreach (var f in packageFiles)
         {
-            if (Path.GetFileName(f).ToLowerInvariant() == @"license")
+            if (Path.GetFileNameWithoutExtension(f).ToLowerInvariant() == @"license")
                 packageReader.GetBytes(f);
         }
 

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -108,7 +108,7 @@ public static class PackageArchiveReaderExtension
         return Encoding.Default.GetString(data);
     }
 
-    public static byte[]? GetLicenseFile(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
+    public static byte[]? GetLicenseFile(this PackageArchiveReader packageReader)
     {
         var packageFiles = packageReader.GetFiles();
         foreach (var f in packageFiles)
@@ -122,7 +122,7 @@ public static class PackageArchiveReaderExtension
 
     public static string GetLicense(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
     {
-        byte[]? data = packageReader.GetLicenseFile(nuspecReader);
+        byte[]? data = packageReader.GetLicenseFile();
         if (data == null || data.Length == 0)
             return string.Empty;
 

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -67,17 +67,14 @@ public static class PackageArchiveReaderExtension
         );
     }
 
-    public static TarGz.FileDictionary GetAdditionalFiles(
-        this PackageArchiveReader packageReader,
-        NuspecReader nuspecReader
-    )
+    public static TarGz.FileDictionary GetAdditionalFiles(this PackageArchiveReader packageReader)
     {
         List<string> additionalFiles =
             new()
             {
-                nuspecReader.GetIcon(),
-                nuspecReader.GetReadme(),
-                nuspecReader.GetReleaseNotes(),
+                packageReader.NuspecReader.GetIcon(),
+                packageReader.NuspecReader.GetReadme(),
+                packageReader.NuspecReader.GetReleaseNotes(),
                 "LICENSE.TXT",
                 "LICENSE.md",
                 "LICENSE",

--- a/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
+++ b/NuGettier.Upm/NugetExtensions/PackageArchiveReaderExtension.cs
@@ -91,17 +91,17 @@ public static class PackageArchiveReaderExtension
         );
     }
 
-    public static byte[]? GetReadmeFile(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
+    public static byte[]? GetReadmeFile(this PackageArchiveReader packageReader)
     {
-        if (string.IsNullOrEmpty(nuspecReader.GetReadme()))
+        if (string.IsNullOrEmpty(packageReader.NuspecReader.GetReadme()))
             return null;
 
-        return packageReader.GetBytes(nuspecReader.GetReadme());
+        return packageReader.GetBytes(packageReader.NuspecReader.GetReadme());
     }
 
     public static string GetReadme(this PackageArchiveReader packageReader, NuspecReader nuspecReader)
     {
-        byte[]? data = packageReader.GetReadmeFile(nuspecReader);
+        byte[]? data = packageReader.GetReadmeFile();
         if (data == null || data.Length == 0)
             return string.Empty;
 

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -53,7 +53,7 @@ public static partial class Program
         if (packageStream != null)
         {
             using PackageArchiveReader packageReader = new PackageArchiveReader(packageStream);
-            NuspecReader nuspecReader = await packageReader.GetNuspecReaderAsync(cancellationToken);
+            NuspecReader nuspecReader = packageReader.NuspecReader;
 
             Console.WriteLine($"ID: {nuspecReader.GetId()}");
             Console.WriteLine($"Title: {nuspecReader.GetTitle()}");

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -53,29 +53,28 @@ public static partial class Program
         if (packageStream != null)
         {
             using PackageArchiveReader packageReader = new PackageArchiveReader(packageStream);
-            NuspecReader nuspecReader = packageReader.NuspecReader;
 
-            Console.WriteLine($"ID: {nuspecReader.GetId()}");
-            Console.WriteLine($"Title: {nuspecReader.GetTitle()}");
-            Console.WriteLine($"Summary: {nuspecReader.GetSummary()}");
-            Console.WriteLine($"Copyright: {nuspecReader.GetCopyright()}");
-            Console.WriteLine($"Version: {nuspecReader.GetVersion()}");
-            Console.WriteLine($"Tags: {nuspecReader.GetTags()}");
-            Console.WriteLine($"Readme: {nuspecReader.GetReadme()}");
-            Console.WriteLine($"Icon: {nuspecReader.GetIcon()}");
-            Console.WriteLine($"Description: {nuspecReader.GetDescription()}");
-            Console.WriteLine($"Authors: {nuspecReader.GetAuthors()}");
-            Console.WriteLine($"Owners: {nuspecReader.GetOwners()}");
-            Console.WriteLine($"ReleaseNotes: {nuspecReader.GetReleaseNotes()}");
-            Console.WriteLine($"Project Url: {nuspecReader.GetProjectUrl()}");
-            Console.WriteLine($"LicenseUrl: {nuspecReader.GetLicenseUrl()}");
-            Console.WriteLine($"Icon Url: {nuspecReader.GetIconUrl()}");
-            Console.WriteLine($"Language: {nuspecReader.GetLanguage()}");
-            Console.WriteLine($"LicenseMetadata: {nuspecReader.GetLicenseMetadata()}");
-            Console.WriteLine($"RepositoryMetadata: {nuspecReader.GetRepositoryMetadata()}");
+            Console.WriteLine($"ID: {packageReader.NuspecReader.GetId()}");
+            Console.WriteLine($"Title: {packageReader.NuspecReader.GetTitle()}");
+            Console.WriteLine($"Summary: {packageReader.NuspecReader.GetSummary()}");
+            Console.WriteLine($"Copyright: {packageReader.NuspecReader.GetCopyright()}");
+            Console.WriteLine($"Version: {packageReader.NuspecReader.GetVersion()}");
+            Console.WriteLine($"Tags: {packageReader.NuspecReader.GetTags()}");
+            Console.WriteLine($"Readme: {packageReader.NuspecReader.GetReadme()}");
+            Console.WriteLine($"Icon: {packageReader.NuspecReader.GetIcon()}");
+            Console.WriteLine($"Description: {packageReader.NuspecReader.GetDescription()}");
+            Console.WriteLine($"Authors: {packageReader.NuspecReader.GetAuthors()}");
+            Console.WriteLine($"Owners: {packageReader.NuspecReader.GetOwners()}");
+            Console.WriteLine($"ReleaseNotes: {packageReader.NuspecReader.GetReleaseNotes()}");
+            Console.WriteLine($"Project Url: {packageReader.NuspecReader.GetProjectUrl()}");
+            Console.WriteLine($"LicenseUrl: {packageReader.NuspecReader.GetLicenseUrl()}");
+            Console.WriteLine($"Icon Url: {packageReader.NuspecReader.GetIconUrl()}");
+            Console.WriteLine($"Language: {packageReader.NuspecReader.GetLanguage()}");
+            Console.WriteLine($"LicenseMetadata: {packageReader.NuspecReader.GetLicenseMetadata()}");
+            Console.WriteLine($"RepositoryMetadata: {packageReader.NuspecReader.GetRepositoryMetadata()}");
 
             Console.WriteLine("Dependencies:");
-            foreach (var dependencyGroup in nuspecReader.GetDependencyGroups())
+            foreach (var dependencyGroup in packageReader.NuspecReader.GetDependencyGroups())
             {
                 Console.WriteLine($"- {dependencyGroup.TargetFramework.GetShortFolderName()}:");
                 foreach (var dependency in dependencyGroup.Packages)
@@ -85,7 +84,7 @@ public static partial class Program
             }
 
             Console.WriteLine("Framework Assembly Groups:");
-            foreach (var group in nuspecReader.GetFrameworkAssemblyGroups())
+            foreach (var group in packageReader.NuspecReader.GetFrameworkAssemblyGroups())
             {
                 Console.WriteLine($"- TargetFramework: {group.TargetFramework.ToString()}");
                 Console.WriteLine($"  HasEmptyFolder: {group.HasEmptyFolder}");
@@ -97,7 +96,7 @@ public static partial class Program
             }
 
             Console.WriteLine("Reference Groups:");
-            foreach (var group in nuspecReader.GetReferenceGroups())
+            foreach (var group in packageReader.NuspecReader.GetReferenceGroups())
             {
                 Console.WriteLine($"- TargetFramework: {group.TargetFramework.ToString()}");
                 Console.WriteLine($"  HasEmptyFolder: {group.HasEmptyFolder}");
@@ -110,7 +109,7 @@ public static partial class Program
 
             // not very interesting (empty)
             Console.WriteLine("Content Files:");
-            foreach (var file in nuspecReader.GetContentFiles())
+            foreach (var file in packageReader.NuspecReader.GetContentFiles())
             {
                 Console.WriteLine($"- file:");
                 Console.WriteLine($"  Include: {file.Include}");
@@ -127,7 +126,7 @@ public static partial class Program
             }
 
             //Console.WriteLine($"{JsonSerializer.Serialize(packageReader, new JsonSerializerOptions(){ReferenceHandler = ReferenceHandler.Preserve})}");
-            //Console.WriteLine($"{JsonSerializer.Serialize(nuspecReader, new JsonSerializerOptions(){ReferenceHandler = ReferenceHandler.Preserve})}");
+            //Console.WriteLine($"{JsonSerializer.Serialize(packageReader.NuspecReader, new JsonSerializerOptions(){ReferenceHandler = ReferenceHandler.Preserve})}");
 
             if (!outputDirectory.Exists)
             {
@@ -136,7 +135,7 @@ public static partial class Program
 
             using (
                 FileStream fileStream = new FileStream(
-                    $"{Path.Join(outputDirectory.FullName, $"{nuspecReader.GetId()}-{nuspecReader.GetVersion()}.nupkg")}",
+                    $"{Path.Join(outputDirectory.FullName, $"{packageReader.NuspecReader.GetId()}-{packageReader.NuspecReader.GetVersion()}.nupkg")}",
                     FileMode.Create,
                     FileAccess.Write
                 )

--- a/Prototype/Program.cs
+++ b/Prototype/Program.cs
@@ -136,7 +136,7 @@ await findPackageByIdResource.CopyNupkgToStreamAsync(
 Console.WriteLine($"Downloaded package {PACKAGE} {packageVersion}");
 
 using PackageArchiveReader packageReader = new PackageArchiveReader(packageStream);
-NuspecReader nuspecReader = await packageReader.GetNuspecReaderAsync(cancellationToken);
+NuspecReader nuspecReader = packageReader.NuspecReader;
 
 Console.WriteLine($"Tags: {nuspecReader.GetTags()}");
 Console.WriteLine($"Description: {nuspecReader.GetDescription()}");

--- a/Prototype/Program.cs
+++ b/Prototype/Program.cs
@@ -136,22 +136,21 @@ await findPackageByIdResource.CopyNupkgToStreamAsync(
 Console.WriteLine($"Downloaded package {PACKAGE} {packageVersion}");
 
 using PackageArchiveReader packageReader = new PackageArchiveReader(packageStream);
-NuspecReader nuspecReader = packageReader.NuspecReader;
 
-Console.WriteLine($"Tags: {nuspecReader.GetTags()}");
-Console.WriteLine($"Description: {nuspecReader.GetDescription()}");
+Console.WriteLine($"Tags: {packageReader.NuspecReader.GetTags()}");
+Console.WriteLine($"Description: {packageReader.NuspecReader.GetDescription()}");
 #endregion
 
 
 #region read package
-Console.WriteLine($"ID: {nuspecReader.GetId()}");
+Console.WriteLine($"ID: {packageReader.NuspecReader.GetId()}");
 
-Console.WriteLine($"Version: {nuspecReader.GetVersion()}");
-Console.WriteLine($"Description: {nuspecReader.GetDescription()}");
-Console.WriteLine($"Authors: {nuspecReader.GetAuthors()}");
+Console.WriteLine($"Version: {packageReader.NuspecReader.GetVersion()}");
+Console.WriteLine($"Description: {packageReader.NuspecReader.GetDescription()}");
+Console.WriteLine($"Authors: {packageReader.NuspecReader.GetAuthors()}");
 
 Console.WriteLine("Dependencies:");
-foreach (var dependencyGroup in nuspecReader.GetDependencyGroups())
+foreach (var dependencyGroup in packageReader.NuspecReader.GetDependencyGroups())
 {
     Console.WriteLine($" - {dependencyGroup.TargetFramework.GetShortFolderName()}");
     foreach (var dependency in dependencyGroup.Packages)


### PR DESCRIPTION
- refactor (NuGettier): use PackageArchiveReader.NuspecReader directly in 'Get' command
- refactor (NuGettier.Upm): use PackageArchiveReader.NuspecReader directly in Upm.Context.PackUpmPackage()
- refactor (Prototype): use PackageArchiveReader.NuspecReader directly
- refactor (NuGettier.Upm): remove argument NuspecReader from PackageArchiveReader.GetAdditionalFiles() extension method
- refactor (NuGettier.Upm): remove argument NuspecReader from PackageArchiveReader.GetReadmeFile() extension method
- refactor (NuGettier.Upm): remove argument NuspecReader from PackageArchiveReader.GetReadme() extension method
- refactor (NuGettier.Upm): remove argument NuspecReader from PackageArchiveReader.GetLicenseFile() extension method
- refactor (NuGettier.Upm): remove argument NuspecReader from PackageArchiveReader.GetLicense() extension method
- refactor (NuGettier.Upm): improve license file search method in PackageArchiveReader.GetLicenseFile() extension method
- refactor (NuGettier.Upm): use PackageArchiveReader.NuspecReader directly in Upm.Context.PackUpmPackage()
- refactor (NuGettier): use PackageArchiveReader.NuspecReader directly in 'Get' command
- refactor (Prototype): use PackageArchiveReader.NuspecReader directly
