### PR TITLE
feature (NuGettier.Amalgamate): implement Amalgamate.Context.PackUpmPackage() override to include direct dependency assemblies

### DIFF
--- a/NuGettier.Amalgamate/Context/GetPackageJson.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageJson.cs
@@ -38,7 +38,6 @@ public partial class Context
             return null;
 
         PackageJson packageJson = new(packageJsonOrig);
-        packageJson.Name += ".amalgamate";
         packageJson.DisplayName += " amalgamated with all dependencies";
         packageJson.Description += "\n\nThis package also contains all dependency assemblies";
         packageJson.Dependencies.Clear();

--- a/NuGettier.Amalgamate/Context/PackUpmPackage.cs
+++ b/NuGettier.Amalgamate/Context/PackUpmPackage.cs
@@ -50,10 +50,7 @@ public partial class Context
         if (!string.IsNullOrEmpty(buildmetaSuffix))
             packageJson.Version += $"+{buildmetaSuffix}";
 
-        // get package rule
-        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
-        PackageRule packageRule = GetPackageRule(packageId);
-        Assert.NotNull(packageRule);
+        FileDictionary files = new();
 
         // fetch package contents for NuGet
         using var packageStream = await FetchPackage(
@@ -66,7 +63,7 @@ public partial class Context
 
         using PackageArchiveReader packageReader = new(packageStream);
 
-        var files = packageReader.GetFrameworkFiles(NugetFramework);
+        files.AddRange(packageReader.GetFrameworkFiles(NugetFramework));
         files.AddRange(packageReader.GetAdditionalFiles());
 
         // create & add README
@@ -95,6 +92,36 @@ public partial class Context
             var changelog = packageJson.GenerateChangelog(packageReader.NuspecReader.GetReleaseNotes());
             files.Add(@"CHANGELOG.md", changelog);
             Console.WriteLine($"--- CHANGELOG\n{Encoding.Default.GetString(files[@"CHANGELOG.md"])}\n---");
+        }
+
+        var packageDependencyGroup = NuGetFrameworkUtility.GetNearest<PackageDependencyGroup>(
+            packageReader.NuspecReader.GetDependencyGroups(),
+            NugetFramework
+        );
+
+        if (packageDependencyGroup is not null)
+        {
+            foreach (var dependency in packageDependencyGroup.Packages)
+            {
+                var packageRule = GetPackageRule(dependency.Id);
+                if (packageRule.IsIgnored)
+                    continue;
+
+                if (packageRule.IsExcluded)
+                    continue;
+
+                using var dependencyPackageStream = await FetchPackage(
+                    packageIdVersion: $"{dependency.Id}@{dependency.VersionRange.ToLegacyShortString()}",
+                    preRelease: true,
+                    cancellationToken: cancellationToken
+                );
+                if (dependencyPackageStream == null)
+                    continue;
+
+                using PackageArchiveReader dependencyPackageReader = new(dependencyPackageStream);
+                files.AddRange(dependencyPackageReader.GetFrameworkFiles(NugetFramework));
+                files.AddRange(dependencyPackageReader.GetAdditionalFiles());
+            }
         }
 
         // add file references to package.json

--- a/NuGettier.Amalgamate/Context/PackUpmPackage.cs
+++ b/NuGettier.Amalgamate/Context/PackUpmPackage.cs
@@ -17,12 +17,12 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.GZip;
+using NuGettier.Core;
+using NuGettier.Upm;
 using NuGettier.Upm.TarGz;
 using Xunit;
 
 namespace NuGettier.Amalgamate;
-
-using NuRepository = NuGet.Protocol.Core.Types.Repository;
 
 public partial class Context
 {
@@ -34,12 +34,82 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
-        return await base.PackUpmPackage(
+        // build package.json from package information
+        var packageJson = await GetPackageJson(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,
-            prereleaseSuffix: prereleaseSuffix,
-            buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken
         );
+
+        if (packageJson == null)
+            return null;
+
+        // add version suffixes
+        if (!string.IsNullOrEmpty(prereleaseSuffix))
+            packageJson.Version += $"-{prereleaseSuffix}";
+        if (!string.IsNullOrEmpty(buildmetaSuffix))
+            packageJson.Version += $"+{buildmetaSuffix}";
+
+        // get package rule
+        packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
+        PackageRule packageRule = GetPackageRule(packageId);
+        Assert.NotNull(packageRule);
+
+        // fetch package contents for NuGet
+        using var packageStream = await FetchPackage(
+            packageIdVersion: packageIdVersion,
+            preRelease: preRelease,
+            cancellationToken: cancellationToken
+        );
+        if (packageStream == null)
+            return null;
+
+        using PackageArchiveReader packageReader = new(packageStream);
+
+        var files = packageReader.GetFrameworkFiles(NugetFramework);
+        files.AddRange(packageReader.GetAdditionalFiles());
+
+        // create & add README
+        if (!files.ContainsKey(@"README.md"))
+        {
+            var readme = packageJson.GenerateReadme(originalReadme: packageReader.GetReadme());
+            files.Add(@"README.md", readme);
+            Console.WriteLine($"--- README\n{Encoding.Default.GetString(files[@"README.md"])}\n---");
+        }
+
+        // create & add LICENSE
+        if (!files.ContainsKey(@"LICENSE.md"))
+        {
+            var license = packageJson.GenerateLicense(
+                originalLicense: packageReader.GetLicense(),
+                copyright: packageReader.NuspecReader.GetCopyright(),
+                copyrightHolder: packageReader.NuspecReader.GetOwners()
+            );
+            files.Add(@"LICENSE.md", license);
+            Console.WriteLine($"--- LICENSE\n{Encoding.Default.GetString(files[@"LICENSE.md"])}\n---");
+        }
+
+        // create & add CHANGELOG
+        if (!files.ContainsKey(@"CHANGELOG.md"))
+        {
+            var changelog = packageJson.GenerateChangelog(packageReader.NuspecReader.GetReleaseNotes());
+            files.Add(@"CHANGELOG.md", changelog);
+            Console.WriteLine($"--- CHANGELOG\n{Encoding.Default.GetString(files[@"CHANGELOG.md"])}\n---");
+        }
+
+        // add file references to package.json
+        packageJson.Files.AddRange(files.Keys);
+
+        // add package.json to FileDictionary
+        Assert.False(files.ContainsKey(@"package.json"));
+        var packageJsonString = packageJson.ToJson();
+        files.Add(@"package.json", packageJsonString);
+        Console.WriteLine($"--- PACKAGE.JSON\n{packageJsonString}\n---");
+
+        // add meta files
+        files.AddMetaFiles(packageJson.Name);
+
+        var packageIdentifier = $"{packageJson.Name}-{packageJson.Version}";
+        return new Tuple<string, FileDictionary>(packageIdentifier, files);
     }
 }

--- a/NuGettier.Amalgamate/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Amalgamate/Context/PackageMetadataUtility.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Licenses;
+using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
+using HandlebarsDotNet;
+using NuGettier.Upm;
+using Xunit;
+
+namespace NuGettier.Amalgamate;
+
+public partial class Context
+{
+    protected override IDictionary<string, string> GetPackageDependencies(
+        IPackageSearchMetadata packageSearchMetadata,
+        NuGetFramework nugetFramework
+    )
+    {
+        var packageDependencyGroup = NuGetFrameworkUtility.GetNearest<PackageDependencyGroup>(
+            packageSearchMetadata.DependencySets,
+            nugetFramework
+        );
+
+        if (packageDependencyGroup is null)
+            return new Dictionary<string, string>();
+
+        return packageDependencyGroup.Packages.ToDictionary(d => d.Id, d => d.VersionRange.ToLegacyShortString());
+    }
+}

--- a/NuGettier.Amalgamate/Context/Utility.cs
+++ b/NuGettier.Amalgamate/Context/Utility.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Text.RegularExpressions;
+using NuGet.Protocol.Core.Types;
+using Microsoft.Extensions.Configuration;
+using HandlebarsDotNet;
+using NuGettier.Upm;
+using Xunit;
+
+namespace NuGettier.Amalgamate;
+
+public partial class Context
+{
+    protected override string PatchPackageId(string packageId)
+    {
+        return $"{base.PatchPackageId(packageId)}.amalgamate";
+    }
+}

--- a/NuGettier.Amalgamate/Context/Utility.cs
+++ b/NuGettier.Amalgamate/Context/Utility.cs
@@ -18,4 +18,16 @@ public partial class Context
     {
         return $"{base.PatchPackageId(packageId)}.amalgamate";
     }
+
+    protected override IDictionary<string, string> PatchPackageDependencies(IDictionary<string, string> dependencies)
+    {
+        return dependencies
+            .Where(d => GetPackageRule(d.Key).IsIgnored == false) //< filter: remove 'ignored' dependencies
+            .Where(d => GetPackageRule(d.Key).IsExcluded == true) //< filter: 'excluded' dependencies are not amalgamated
+            .ToDictionary(
+                //< calling the base method allows to override PatchPackageId, PatchPackageVersion without affecting the dependencies
+                d => base.PatchPackageId(d.Key),
+                d => base.PatchPackageVersion(d.Key, d.Value)
+            );
+    }
 }

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="version metadata">
-    <Version>0.0.99</Version>
+    <Version>0.1.0-0</Version>
     <AssemblyVersion>0.0.99.99</AssemblyVersion>
     <FileVersion>0.0.99.51</FileVersion>
   </PropertyGroup>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="version metadata">
-    <Version>0.0.99</Version>
+    <Version>0.1.0-0</Version>
     <AssemblyVersion>0.0.99.99</AssemblyVersion>
     <FileVersion>0.0.99.406</FileVersion>
   </PropertyGroup>

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Collections;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Text.RegularExpressions;
@@ -9,6 +10,8 @@ using HandlebarsDotNet;
 using Xunit;
 
 namespace NuGettier.Upm;
+
+#nullable enable
 
 public partial class Context
 {
@@ -80,6 +83,13 @@ public partial class Context
         Console.WriteLine($"after: {packageId}: {result}");
 
         return result;
+    }
+
+    protected virtual IDictionary<string, string> PatchPackageDependencies(IDictionary<string, string> dependencies)
+    {
+        return dependencies
+            .Where(d => GetPackageRule(d.Key).IsIgnored == false) //< filter: remove 'ignored' dependencies
+            .ToDictionary(d => PatchPackageId(d.Key), d => PatchPackageVersion(d.Key, d.Value));
     }
 
     protected virtual PackageJson ConvertToPackageJson(IPackageSearchMetadata packageSearchMetadata)

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -33,9 +33,7 @@ public partial class Context
         packageJson.MinUnityVersion = MinUnityVersion;
 
         // filter and patch dependencies' name and version
-        packageJson.Dependencies = packageJson.Dependencies
-            .Where(d => GetPackageRule(d.Key).IsIgnored == false) //< filter
-            .ToDictionary(d => PatchPackageId(d.Key), d => PatchPackageVersion(d.Key, d.Value));
+        packageJson.Dependencies = PatchPackageDependencies(packageJson.Dependencies);
 
         // basically tag as 'nugettier was here'
         packageJson.DevDependencies ??= new StringStringDictionary();

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="version metadata">
-    <Version>0.0.99</Version>
+    <Version>0.1.0-0</Version>
     <AssemblyVersion>0.0.99.99</AssemblyVersion>
     <FileVersion>0.0.99.531</FileVersion>
   </PropertyGroup>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="version metadata">
-    <Version>0.0.99</Version>
+    <Version>0.1.0-0</Version>
     <AssemblyVersion>0.0.99.99</AssemblyVersion>
     <FileVersion>0.0.99.374</FileVersion>
   </PropertyGroup>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="version metadata">
-    <Version>0.0.99</Version>
+    <Version>0.1.0-0</Version>
     <AssemblyVersion>0.0.99.99</AssemblyVersion>
     <FileVersion>0.0.99.798</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
- feature (NuGettier.Upm): implement Upm.Context.PatchPackageDependencies() virtual method
- refactor (NuGettier.Upm): call Upm.Context.PatchPackageDependencies() to filter/patch dependency package id and version
- feature (NuGettier.Amalgamate): implement Amalgamate.Context.PatchPackageId() override
- feature (NuGettier.Amalgamate): implement Amalgamate.Context.PatchPackageDependencies() override
- feature (NuGettier.Amalgamate): implement Amalgamate.Context.GetPackageDependencies() override
- feature (NuGettier.Amalgamate): implement Amalgamate.Context.PackUpmPackage() override
- refactor (NuGettier.Amalgamate): adapt Amalgamate.Context.PackUpmPackage() to include direct dependency assemblies
