### PR TITLE
feature (NuGettier.Upm): unify package file retrieval

### DIFF
--- a/NuGettier.Amalgamate/Context/GetPackageFiles.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageFiles.cs
@@ -23,7 +23,7 @@ namespace NuGettier.Amalgamate;
 
 public partial class Context
 {
-    public async Task<FileDictionary> GetPackageFiles(
+    public async override Task<FileDictionary> GetPackageFiles(
         PackageArchiveReader packageReader,
         NuGetFramework nuGetFramework,
         CancellationToken cancellationToken

--- a/NuGettier.Amalgamate/Context/GetPackageFiles.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageFiles.cs
@@ -25,13 +25,11 @@ public partial class Context
 {
     public async override Task<FileDictionary> GetPackageFiles(
         PackageArchiveReader packageReader,
-        NuGetFramework nuGetFramework,
+        NuGetFramework nugetFramework,
         CancellationToken cancellationToken
     )
     {
-        FileDictionary files = new();
-        files.AddRange(packageReader.GetFrameworkFiles(nuGetFramework));
-        files.AddRange(packageReader.GetAdditionalFiles());
+        FileDictionary files = await base.GetPackageFiles(packageReader, nugetFramework, cancellationToken);
 
         var packageRule = GetPackageRule(packageReader.NuspecReader.GetIdentity().Id);
         Assert.NotNull(packageRule);
@@ -63,7 +61,7 @@ public partial class Context
                         continue;
 
                     using PackageArchiveReader dependencyPackageReader = new(dependencyPackageStream);
-                    files.AddRange(await GetPackageFiles(dependencyPackageReader, nuGetFramework, cancellationToken));
+                    files.AddRange(await GetPackageFiles(dependencyPackageReader, nugetFramework, cancellationToken));
                 }
             }
         }

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -50,7 +50,6 @@ public partial class Context : Core.Context
         Directory = directory;
         CachedMetadata = new Dictionary<string, IPackageSearchMetadata>();
         Framework = GetFrameworkFromUnitySettings(minUnityVersion);
-
     }
 
     public Context(Context other)

--- a/NuGettier.Upm/Context/GetPackageFiles.cs
+++ b/NuGettier.Upm/Context/GetPackageFiles.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json;
+using System.CommandLine;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Xunit;
+using NuGettier.Upm.TarGz;
+
+namespace NuGettier.Upm;
+
+#nullable enable
+
+public partial class Context
+{
+    public async virtual Task<FileDictionary> GetPackageFiles(
+        PackageArchiveReader packageReader,
+        NuGetFramework nugetFramework,
+        CancellationToken cancellationToken
+    )
+    {
+        return await Task.Run(() =>
+        {
+            FileDictionary files = new();
+            files.AddRange(packageReader.GetFrameworkFiles(nugetFramework));
+            files.AddRange(packageReader.GetAdditionalFiles());
+            return files;
+        });
+    }
+}

--- a/NuGettier.Upm/Context/GetPackageInformation.cs
+++ b/NuGettier.Upm/Context/GetPackageInformation.cs
@@ -29,9 +29,9 @@ public partial class Context
     {
         packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         var packageSearchMetadata = await base.GetPackageInformation(
-            packageIdVersion,
-            preRelease,
-            cancellationToken
+            packageIdVersion: packageIdVersion,
+            preRelease: preRelease,
+            cancellationToken: cancellationToken
         );
         if (packageSearchMetadata != null)
         {

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -13,7 +13,6 @@ using NuGet.Shared;
 using HandlebarsDotNet;
 using Xunit;
 
-
 namespace NuGettier.Upm;
 
 public partial class Context


### PR DESCRIPTION
- feature (NuGettier.Upm): implement Upm.Context.GetPackageFiles() as virtual method
- refactor (NuGettier.Amalgamate): change to Amalgamate.Context.GetPackageFiles() to override method
- refactor (NuGettier.Amalgamate): adapt to Amalgamate.Context.GetPackageFiles() to call base method
- refactor (NuGettier.Upm): plug call to .GetPackageFiles() into Upm.Context.PackUpmPackage()
- refactor (NuGettier.Amalgamate): simplify Amalgamate.Context.PackUpmPackage() into simple call to base method
- chore: remove whitespace lines
- refactor (NuGettier.Upm): improve call to Upm.Context.GetPackageInformation() base method
