### PR TITLE
refactor (NuGettier.Upm): improve Upm.Context.GetPackageRule() to always return rule with valid elements

### DIFF
--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -23,13 +23,14 @@ public partial class Context
         if (
             string.IsNullOrEmpty(packageRule.Name)
             || string.IsNullOrEmpty(packageRule.Version)
+            || string.IsNullOrEmpty(packageRule.Framework)
         )
         {
             return new PackageRule(
                 Id: packageRule.Id,
                 Name: string.IsNullOrEmpty(packageRule.Name) ? defaultRule.Name : packageRule.Name,
                 Version: string.IsNullOrEmpty(packageRule.Version) ? defaultRule.Version : packageRule.Version,
-                Framework: packageRule.Framework,
+                Framework: string.IsNullOrEmpty(packageRule.Framework) ? defaultRule.Framework : packageRule.Framework,
                 IsIgnored: packageRule.IsIgnored,
                 IsExcluded: packageRule.IsExcluded,
                 IsRecursive: packageRule.IsRecursive

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -17,9 +17,23 @@ public partial class Context
 {
     public PackageRule GetPackageRule(string packageId)
     {
-        return PackageRules
-            .Where(r => r.Id == packageId)
-            .FirstOrDefault(PackageRules.Where(r => string.IsNullOrEmpty(r.Id)).FirstOrDefault(DefaultPackageRule));
+        var defaultRule = PackageRules.Where(r => string.IsNullOrEmpty(r.Id)).FirstOrDefault(DefaultPackageRule);
+        var packageRule = PackageRules.Where(r => r.Id == packageId).FirstOrDefault(defaultRule);
+
+        if (string.IsNullOrEmpty(packageRule.Name))
+        {
+            return new PackageRule(
+                Id: packageRule.Id,
+                Name: defaultRule.Name,
+                Version: packageRule.Version,
+                Framework: packageRule.Framework,
+                IsIgnored: packageRule.IsIgnored,
+                IsExcluded: packageRule.IsExcluded,
+                IsRecursive: packageRule.IsRecursive
+            );
+        }
+
+        return packageRule;
     }
 
     public virtual PackageJson PatchPackageJson(PackageJson packageJson)

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -20,12 +20,15 @@ public partial class Context
         var defaultRule = PackageRules.Where(r => string.IsNullOrEmpty(r.Id)).FirstOrDefault(DefaultPackageRule);
         var packageRule = PackageRules.Where(r => r.Id == packageId).FirstOrDefault(defaultRule);
 
-        if (string.IsNullOrEmpty(packageRule.Name))
+        if (
+            string.IsNullOrEmpty(packageRule.Name)
+            || string.IsNullOrEmpty(packageRule.Version)
+        )
         {
             return new PackageRule(
                 Id: packageRule.Id,
-                Name: defaultRule.Name,
-                Version: packageRule.Version,
+                Name: string.IsNullOrEmpty(packageRule.Name) ? defaultRule.Name : packageRule.Name,
+                Version: string.IsNullOrEmpty(packageRule.Version) ? defaultRule.Version : packageRule.Version,
                 Framework: packageRule.Framework,
                 IsIgnored: packageRule.IsIgnored,
                 IsExcluded: packageRule.IsExcluded,


### PR DESCRIPTION
- refactor (NuGettier.Upm): improve Upm.Context.GetPackageRule() to return rule with valid .Name element
- refactor (NuGettier.Upm): improve Upm.Context.GetPackageRule() to return valid rule despite null/empty .Version
- refactor (NuGettier.Upm): improve Upm.Context.GetPackageRule() to return valid rule despite null/empty .Framework
