### PR TITLE
refactor: use NLog for logging to silence stdout debug spam

### DIFF
--- a/NuGettier.Amalgamate/Context/Context.cs
+++ b/NuGettier.Amalgamate/Context/Context.cs
@@ -5,11 +5,14 @@ using System.CommandLine;
 using NuGettier;
 using NuGet.Protocol.Core.Types;
 using Microsoft.Extensions.Configuration;
+using NLog;
 
 namespace NuGettier.Amalgamate;
 
 public partial class Context : Upm.Context
 {
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
     public Context(
         IConfigurationRoot configuration,
         IEnumerable<Uri> sources,

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
+    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -64,9 +64,9 @@ public partial class Context : IDisposable
 
         var entryAssembly = Assembly.GetEntryAssembly();
         var assemblyName = entryAssembly?.GetName();
-        console.WriteLine($"assembly name: {assemblyName?.Name}");
-        console.WriteLine($"assembly version: {assemblyName?.Version?.ToString(3)}");
-        console.WriteLine(
+        Logger.Debug($"assembly name: {assemblyName?.Name}");
+        Logger.Debug($"assembly version: {assemblyName?.Version?.ToString(3)}");
+        Logger.Debug(
             $"assembly informational version: {entryAssembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion}"
         );
 
@@ -99,7 +99,7 @@ public partial class Context : IDisposable
         Repositories = Sources.Select(source =>
         {
             var requestSource = source.GetComponents(UriComponents.HttpRequestUrl, UriFormat.UriEscaped);
-            console.WriteLine($"adding source {requestSource}");
+            Logger.Debug($"adding source {requestSource}");
             string? username = null;
             string? password = null;
             if (!string.IsNullOrEmpty(source.UserInfo))
@@ -107,8 +107,8 @@ public partial class Context : IDisposable
                 var userInfo = source.UserInfo.Split(':');
                 username = userInfo[0];
                 password = userInfo[1];
-                console.WriteLine($"\tusername: {username}");
-                console.WriteLine($"\tpassword: {password}");
+                Logger.Debug($"\tusername: {username}");
+                Logger.Debug($"\tpassword: {password}");
             }
             PackageSource packageSource =
                 new(requestSource, source.Authority)
@@ -132,7 +132,7 @@ public partial class Context : IDisposable
             .GetChildren()
             .Select(packageSection =>
             {
-                console.WriteLine($"package key: {packageSection.Key}");
+                Logger.Debug($"package key: {packageSection.Key}");
                 return new PackageRule(
                     Id: packageSection.Key,
                     Name: packageSection.GetValue<string>(kNameKey) ?? string.Empty,
@@ -147,7 +147,7 @@ public partial class Context : IDisposable
 
         foreach (var p in PackageRules)
         {
-            console.WriteLine($"{p}");
+            Logger.Debug($"{p}");
         }
     }
 

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -12,6 +12,7 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Microsoft.Extensions.Configuration;
+using NLog;
 using Xunit;
 
 namespace NuGettier.Core;
@@ -33,6 +34,8 @@ public partial class Context : IDisposable
     protected const string kFrameworkKey = @"framework";
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
+
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     public record class PackageRule(
         string Id,

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -22,6 +22,7 @@
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
+    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -10,6 +10,7 @@ using NuGet.Frameworks;
 using NuGet.Protocol.Core.Types;
 using Microsoft.Extensions.Configuration;
 using System.Diagnostics.CodeAnalysis;
+using NLog;
 
 namespace NuGettier.Upm;
 
@@ -17,6 +18,8 @@ public partial class Context : Core.Context
 {
     protected const string kUnitySection = @"unity";
     protected const string kDefaultFramework = @"netstandard2.0";
+
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     public string MinUnityVersion { get; protected set; }
     public Uri Target { get; protected set; }

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -66,7 +66,7 @@ public partial class Context
         {
             var readme = packageJson.GenerateReadme(originalReadme: packageReader.GetReadme());
             files.Add(@"README.md", readme);
-            Console.WriteLine($"--- README\n{Encoding.Default.GetString(files[@"README.md"])}\n---");
+            Logger.Debug($"--- README\n{Encoding.Default.GetString(files[@"README.md"])}\n---");
         }
 
         // create & add LICENSE
@@ -78,7 +78,7 @@ public partial class Context
                 copyrightHolder: packageReader.NuspecReader.GetOwners()
             );
             files.Add(@"LICENSE.md", license);
-            Console.WriteLine($"--- LICENSE\n{Encoding.Default.GetString(files[@"LICENSE.md"])}\n---");
+            Logger.Debug($"--- LICENSE\n{Encoding.Default.GetString(files[@"LICENSE.md"])}\n---");
         }
 
         // create & add CHANGELOG
@@ -86,7 +86,7 @@ public partial class Context
         {
             var changelog = packageJson.GenerateChangelog(packageReader.NuspecReader.GetReleaseNotes());
             files.Add(@"CHANGELOG.md", changelog);
-            Console.WriteLine($"--- CHANGELOG\n{Encoding.Default.GetString(files[@"CHANGELOG.md"])}\n---");
+            Logger.Debug($"--- CHANGELOG\n{Encoding.Default.GetString(files[@"CHANGELOG.md"])}\n---");
         }
 
         // add file references to package.json
@@ -96,7 +96,7 @@ public partial class Context
         Assert.False(files.ContainsKey(@"package.json"));
         var packageJsonString = packageJson.ToJson();
         files.Add(@"package.json", packageJsonString);
-        Console.WriteLine($"--- PACKAGE.JSON\n{packageJsonString}\n---");
+        Logger.Debug($"--- PACKAGE.JSON\n{packageJsonString}\n---");
 
         // add meta files
         files.AddMetaFiles(packageJson.Name);

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -98,11 +98,11 @@ public partial class Context
                     Logger.Info($"NPM: {stdout}");
 
                 if (!string.IsNullOrEmpty(stderr))
-                    Console.Error.WriteLine($"NPM: {stderr}");
+                    Logger.Error($"NPM: {stderr}");
             }
             catch (Exception e)
             {
-                Console.Error.WriteLine($"NPM: {e.Message}");
+                Logger.Error($"NPM: {e.Message}");
             }
 
             System.IO.Directory.Delete(tempDir, recursive: true);

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -95,7 +95,7 @@ public partial class Context
                 var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
 
                 if (!string.IsNullOrEmpty(stdout))
-                    Console.WriteLine($"NPM: {stdout}");
+                    Logger.Info($"NPM: {stdout}");
 
                 if (!string.IsNullOrEmpty(stderr))
                     Console.Error.WriteLine($"NPM: {stderr}");

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -72,7 +72,7 @@ public partial class Context
 
     protected virtual string PatchPackageId(string packageId)
     {
-        Console.WriteLine($"before: {packageId}");
+        Logger.Debug($"before: {packageId}");
         var metadata = CachedMetadata[packageId.ToLowerInvariant()];
         Assert.NotNull(metadata);
 
@@ -83,20 +83,20 @@ public partial class Context
 
         var template = Handlebars.Compile(namingTemplate);
         var result = Regex.Replace(template(metadata).ToLowerInvariant().Replace(@" ", ""), @"\W", @".");
-        Console.WriteLine($"after: {result}");
+        Logger.Debug($"after: {result}");
         return result;
     }
 
     protected virtual string PatchPackageVersion(string packageId, string packageVersion)
     {
-        Console.WriteLine($"before: {packageId}: {packageVersion}");
+        Logger.Debug($"before: {packageId}: {packageVersion}");
         var packageRule = GetPackageRule(packageId);
         var versionRegex = !string.IsNullOrEmpty(packageRule.Version)
             ? packageRule.Version
             : Context.DefaultPackageRule.Version;
 
         var result = Regex.Match(packageVersion, versionRegex).Value;
-        Console.WriteLine($"after: {packageId}: {result}");
+        Logger.Debug($"after: {packageId}: {result}");
 
         return result;
     }

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
+    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="DotNetConfig" Version="1.0.6"/>
     <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
+    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -39,7 +39,7 @@ public static partial class Program
                 builder.ForLogger().FilterMinLevel(LogLevel.Info).WriteToConsole();
                 builder.ForLogger().FilterMinLevel(LogLevel.Debug).WriteToFile(fileName: "nugettier.log");
             });
-        Console.WriteLine($"called with args: {string.Join(" ", args.Select(a => $"'{a}'"))}");
+        Logger.Debug($"called with args: {string.Join(" ", args.Select(a => $"'{a}'"))}");
         Assert.NotNull(Configuration);
 
         var cmd = new RootCommand("Extended NuGet helper utility")

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -9,6 +9,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using DotNetConfig;
 using Microsoft.Extensions.Configuration;
+using NLog;
 using Xunit;
 
 #nullable enable
@@ -29,6 +30,13 @@ public static partial class Program
 
     static async Task<int> Main(string[] args)
     {
+        LogManager
+            .Setup()
+            .LoadConfiguration(builder =>
+            {
+                builder.ForLogger().FilterMinLevel(LogLevel.Info).WriteToConsole();
+                builder.ForLogger().FilterMinLevel(LogLevel.Debug).WriteToFile(fileName: "nugettier.log");
+            });
         Console.WriteLine($"called with args: {string.Join(" ", args.Select(a => $"'{a}'"))}");
         Assert.NotNull(Configuration);
 

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -28,6 +28,8 @@ public static partial class Program
         }
     }
 
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
     static async Task<int> Main(string[] args)
     {
         LogManager

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -80,7 +80,7 @@ public static partial class Program
             using (package)
             {
                 // write output package.tar.gz
-                Console.WriteLine($"writing package {packageIdentifier}.tgz");
+                Logger.Info($"writing package {packageIdentifier}.tgz");
                 await package.WriteToTarGzAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}.tgz"));
                 return 0;
             }

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -73,7 +73,7 @@ public static partial class Program
 
         if (result != 0)
         {
-            console.Error.WriteLine($"publishing failed");
+            Logger.Error($"publishing failed");
         }
 
         return result;

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -80,7 +80,7 @@ public static partial class Program
             using (package)
             {
                 // write output package.tar.gz
-                Console.WriteLine($"writing unpacked package {packageIdentifier}");
+                Logger.Info($"writing unpacked package {packageIdentifier}");
                 await package.WriteToDirectoryAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}"));
                 return 0;
             }

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -79,7 +79,7 @@ public static partial class Program
             using (package)
             {
                 // write output package.tar.gz
-                Console.WriteLine($"writing package {packageIdentifier}.tgz");
+                Logger.Info($"writing package {packageIdentifier}.tgz");
                 await package.WriteToTarGzAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}.tgz"));
                 return 0;
             }

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -73,7 +73,7 @@ public static partial class Program
 
         if (result != 0)
         {
-            console.Error.WriteLine($"publishing failed");
+            Logger.Error($"publishing failed");
         }
 
         return result;

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -79,7 +79,7 @@ public static partial class Program
             using (package)
             {
                 // write output package.tar.gz
-                Console.WriteLine($"writing unpacked package {packageIdentifier}");
+                Logger.Info($"writing unpacked package {packageIdentifier}");
                 await package.WriteToDirectoryAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}"));
                 return 0;
             }

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="7.0.0"/>
+    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>


### PR DESCRIPTION
- build (NuGettier): add dependency on NLog
- build (NuGettier.Core): add dependency on NLog
- build (NuGettier.Upm): add dependency on NLog
- build (NuGettier.Amalgamate): add dependency on NLog
- build (Prototype): add dependency on NLog
- feature (NuGettier): setup NLog.LogManager in code
- feature (NuGettier): add NLog.Logger to Program
- refactor (NuGettier): replace Program debug logs with NLog.Logger calls
- refactor (NuGettier): replace Program info logs with NLog.Logger calls
- refactor (NuGettier): replace Program error logs with NLog.Logger calls
- feature (NuGettier.Core): add NLog.Logger to Core.Context
- refactor (NuGettier.Core): replace Core.Context error logs with NLog.Logger calls
- feature (NuGettier.Upm): add NLog.Logger to Upm.Context
- refactor (NuGettier.Upm): replace Upm.Context debug logs with NLog.Logger calls
- refactor (NuGettier.Upm): replace Upm.Context info logs with NLog.Logger calls
- refactor (NuGettier.Upm): replace Upm.Context error logs with NLog.Logger calls
- feature (NuGettier.Amalgamate): add NLog.Logger to Amalgamate.Context
