### PR TITLE
refactor (NuGettier.Amalgamate): handle adding duplicate files in recursive Amalgamate.Context.GetPackageFiles()

### DIFF
--- a/NuGettier.Amalgamate/Context/GetPackageFiles.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageFiles.cs
@@ -62,7 +62,7 @@ public partial class Context
 
                     using PackageArchiveReader dependencyPackageReader = new(dependencyPackageStream);
                     var packageFiles = await GetPackageFiles(dependencyPackageReader, nugetFramework, cancellationToken);
-                    files.AddRange(packageFiles);
+                    files.AddRange(packageFiles.Where(f => !files.ContainsKey(f.Key)));
                 }
             }
         }

--- a/NuGettier.Amalgamate/Context/GetPackageFiles.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageFiles.cs
@@ -61,7 +61,8 @@ public partial class Context
                         continue;
 
                     using PackageArchiveReader dependencyPackageReader = new(dependencyPackageStream);
-                    files.AddRange(await GetPackageFiles(dependencyPackageReader, nugetFramework, cancellationToken));
+                    var packageFiles = await GetPackageFiles(dependencyPackageReader, nugetFramework, cancellationToken);
+                    files.AddRange(packageFiles);
                 }
             }
         }


### PR DESCRIPTION
- refactor (NuGettier.Amalgamate): split recursive file retrieval into 2 steps in Amalgamate.Context.GetPackageFiles()
- refactor (NuGettier.Amalgamate): add only new files to existing file dictionary in Amalgamate.Context.GetPackageFiles()
