### PR TITLE
refactor (NuGettier): mark unused options as obsolete

### DIFF
--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -35,6 +35,7 @@ public static partial class Program
     private static Option<string> SpecificVersionOption =
         new(aliases: new string[] { "--version", "-v" }, description: "version to fetch");
 
+    [Obsolete("'--framework' option has been superseded by '--unity' option", true)]
     private static Option<string> FrameworkOption =
         new(aliases: new string[] { "--framework", "-f" }, description: "framework of DLL to repack");
 

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -54,6 +54,7 @@ public static partial class Program
             Arity = ArgumentArity.OneOrMore,
         };
 
+    [Obsolete("'--username' and '--password' options have been removed", true)]
     private static Option<string> SourceRepositoryUsernameOption =
         new(
             aliases: new string[] { "--username", },

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -31,6 +31,7 @@ public static partial class Program
     private static Option<bool> RetrieveLatestOption =
         new(aliases: new string[] { "--latest", "-l" }, description: "fetch the latest version");
 
+    [Obsolete("'--latest' and '--version' options have been removed", true)]
     private static Option<string> SpecificVersionOption =
         new(aliases: new string[] { "--version", "-v" }, description: "version to fetch");
 

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -75,11 +75,16 @@ public static partial class Program
         };
 
     private static Option<Uri> TargetRegistryOption =
-        new(aliases: new string[] { "--target", "-t" }, description: "target NPM registry to publish to")
+        new(
+            aliases: new string[] { "--target", "-t" },
+            description: "target NPM registry to publish to",
+            getDefaultValue: () => new Uri("https://foo.bar")
+        )
         {
             IsRequired = true,
         };
 
+    [Obsolete("'--latest' and '--version' options have been removed", true)]
     private static void ValidateLatestOrVersion(CommandResult commandResult)
     {
         commandResult.ValidateOnlyOneOf(RetrieveLatestOption, SpecificVersionOption);

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -27,6 +27,7 @@ public static partial class Program
     private static Option<bool> IncludeDependenciesOption =
         new(aliases: new string[] { "--includeDependencies", "-i" }, description: "whether to include dependencies");
 
+    [Obsolete("'--latest' and '--version' options have been removed", true)]
     private static Option<bool> RetrieveLatestOption =
         new(aliases: new string[] { "--latest", "-l" }, description: "fetch the latest version");
 

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -64,6 +64,7 @@ public static partial class Program
             IsRequired = false, // optional, b/c public repos don't need one
         };
 
+    [Obsolete("'--username' and '--password' options have been removed", true)]
     private static Option<string> SourceRepositoryPasswordOption =
         new(
             aliases: new string[] { "--password", },


### PR DESCRIPTION
- refactor (NuGettier): mark option '--latest' as obsolete
- refactor (NuGettier): mark option '--version' as obsolete
- refactor (NuGettier): mark option '--framework' as obsolete
- refactor (NuGettier): mark option '--username' as obsolete
- refactor (NuGettier): mark option '--password' as obsolete
- refactor (NuGettier): mark option validation method ValidateLatestOrVersion() as obsolete
