### PR TITLE
refactor (NuGettier): provide default values to some options

### DIFF
--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -28,7 +28,11 @@ public static partial class Program
         new(aliases: new string[] { "--includeDependencies", "-i" }, description: "whether to include dependencies");
 
     private static Option<DirectoryInfo> OutputDirectoryOption =
-        new(aliases: new string[] { "--outputDirectory", "-o" }, description: "directory to output files to")
+        new(
+            aliases: new string[] { "--outputDirectory", "-o" },
+            description: "directory to output files to",
+            getDefaultValue: () => new DirectoryInfo(Environment.CurrentDirectory)
+        )
         {
             IsRequired = true,
         };

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -32,7 +32,8 @@ public static partial class Program
     private static Option<string> UpmBuildmetaSuffixOption =
         new(
             aliases: new string[] { "--buildmeta-suffix", },
-            description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)"
+            description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)",
+            getDefaultValue: () => ""
         );
 
     private static Option<string> UpmTokenOption =

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -13,7 +13,11 @@ namespace NuGettier;
 public static partial class Program
 {
     private static Option<string> UpmUnityVersionOption =
-        new(aliases: new string[] { "--unity", "-u" }, description: "minimum Unity version required by package.json")
+        new(
+            aliases: new string[] { "--unity", "-u" },
+            description: "minimum Unity version required by package.json",
+            getDefaultValue: () => "2022.3" //< latest LTS
+        )
         {
             IsRequired = true,
         };

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -25,7 +25,8 @@ public static partial class Program
     private static Option<string> UpmPrereleaseSuffixOption =
         new(
             aliases: new string[] { "--prerelease-suffix", },
-            description: "version prerelease suffix ('foobar' -> '1.2.3-foobar+buildmeta)"
+            description: "version prerelease suffix ('foobar' -> '1.2.3-foobar+buildmeta)",
+            getDefaultValue: () => ""
         );
 
     private static Option<string> UpmBuildmetaSuffixOption =


### PR DESCRIPTION
- refactor (NuGettier): provide default value to option '--outputDirectory'
- refactor (NuGettier): provide default value to option '--unity'
- refactor (NuGettier): provide default value to option '--prerelease-suffix'
- refactor (NuGettier): provide default value to option '--buildmeta-suffix'
