### PR TITLE
refactor (NuGettier): provide default values from .netconfig

### DIFF
--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -7,6 +7,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
+using Microsoft.Extensions.Configuration;
 
 namespace NuGettier;
 
@@ -31,7 +32,11 @@ public static partial class Program
         new(
             aliases: new string[] { "--outputDirectory", "-o" },
             description: "directory to output files to",
-            getDefaultValue: () => new DirectoryInfo(Environment.CurrentDirectory)
+            getDefaultValue: () =>
+                new DirectoryInfo(
+                    Configuration.GetSection("default").GetValue<string>("output-directory")
+                        ?? Environment.CurrentDirectory
+                )
         )
         {
             IsRequired = true,

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -55,7 +55,8 @@ public static partial class Program
         new(
             aliases: new string[] { "--target", "-t" },
             description: "target NPM registry to publish to",
-            getDefaultValue: () => new Uri("https://foo.bar")
+            getDefaultValue: () =>
+                new Uri(Configuration.GetSection("default").GetValue<string>("target") ?? "https://foo.bar")
         )
         {
             IsRequired = true,

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -7,6 +7,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
+using Microsoft.Extensions.Configuration;
 
 namespace NuGettier;
 
@@ -16,7 +17,7 @@ public static partial class Program
         new(
             aliases: new string[] { "--unity", "-u" },
             description: "minimum Unity version required by package.json",
-            getDefaultValue: () => "2022.3" //< latest LTS
+            getDefaultValue: () => Configuration.GetSection("default").GetValue<string>("unity") ?? "2022.3" //< latest LTS
         )
         {
             IsRequired = true,

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -35,7 +35,8 @@ public static partial class Program
         new(
             aliases: new string[] { "--buildmeta-suffix", },
             description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)",
-            getDefaultValue: () => ""
+            getDefaultValue: () =>
+                Configuration.GetSection("default").GetValue<string>("buildmeta-suffix") ?? string.Empty
         );
 
     private static Option<string> UpmTokenOption =

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -27,7 +27,8 @@ public static partial class Program
         new(
             aliases: new string[] { "--prerelease-suffix", },
             description: "version prerelease suffix ('foobar' -> '1.2.3-foobar+buildmeta)",
-            getDefaultValue: () => ""
+            getDefaultValue: () =>
+                Configuration.GetSection("default").GetValue<string>("prerelease-suffix") ?? string.Empty
         );
 
     private static Option<string> UpmBuildmetaSuffixOption =


### PR DESCRIPTION
- refactor (NuGettier): provide default value to option '--outputDirectory' from netconfig [default] section
- refactor (NuGettier): provide default value to option '--target' from netconfig [default] section
- refactor (NuGettier): provide default value to option '--unity' from netconfig [default] section
- refactor (NuGettier): provide default value to option '--prerelease-suffix' from netconfig [default] section
- refactor (NuGettier): provide default value to option '--buildmeta-suffix' from netconfig [default] section
