### PR TITLE
refactor (NuGettier): use constant string for 'defaults' section and value keys

### DIFF
--- a/NuGettier/Constants.cs
+++ b/NuGettier/Constants.cs
@@ -8,4 +8,5 @@ public static partial class Program
     const string kOutputDirectoryKey = "output-directory";
     const string kTargetKey = "target";
     const string kUnityKey = "unity";
+    const string kPrereleaseSuffixKey = "prerelease-suffix";
 }

--- a/NuGettier/Constants.cs
+++ b/NuGettier/Constants.cs
@@ -5,4 +5,5 @@ namespace NuGettier;
 public static partial class Program
 {
     const string kDefaultsSection = "defaults";
+    const string kOutputDirectoryKey = "output-directory";
 }

--- a/NuGettier/Constants.cs
+++ b/NuGettier/Constants.cs
@@ -7,4 +7,5 @@ public static partial class Program
     const string kDefaultsSection = "defaults";
     const string kOutputDirectoryKey = "output-directory";
     const string kTargetKey = "target";
+    const string kUnityKey = "unity";
 }

--- a/NuGettier/Constants.cs
+++ b/NuGettier/Constants.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace NuGettier;
+
+public static partial class Program
+{
+    const string kDefaultsSection = "defaults";
+}

--- a/NuGettier/Constants.cs
+++ b/NuGettier/Constants.cs
@@ -9,4 +9,5 @@ public static partial class Program
     const string kTargetKey = "target";
     const string kUnityKey = "unity";
     const string kPrereleaseSuffixKey = "prerelease-suffix";
+    const string kBuildmetaSuffixKey = "buildmeta-suffix";
 }

--- a/NuGettier/Constants.cs
+++ b/NuGettier/Constants.cs
@@ -6,4 +6,5 @@ public static partial class Program
 {
     const string kDefaultsSection = "defaults";
     const string kOutputDirectoryKey = "output-directory";
+    const string kTargetKey = "target";
 }

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -34,7 +34,7 @@ public static partial class Program
             description: "directory to output files to",
             getDefaultValue: () =>
                 new DirectoryInfo(
-                    Configuration.GetSection(kDefaultsSection).GetValue<string>("output-directory")
+                    Configuration.GetSection(kDefaultsSection).GetValue<string>(kOutputDirectoryKey)
                         ?? Environment.CurrentDirectory
                 )
         )

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -34,7 +34,7 @@ public static partial class Program
             description: "directory to output files to",
             getDefaultValue: () =>
                 new DirectoryInfo(
-                    Configuration.GetSection("default").GetValue<string>("output-directory")
+                    Configuration.GetSection(kDefaultsSection).GetValue<string>("output-directory")
                         ?? Environment.CurrentDirectory
                 )
         )
@@ -56,7 +56,7 @@ public static partial class Program
             aliases: new string[] { "--target", "-t" },
             description: "target NPM registry to publish to",
             getDefaultValue: () =>
-                new Uri(Configuration.GetSection("default").GetValue<string>("target") ?? "https://foo.bar")
+                new Uri(Configuration.GetSection(kDefaultsSection).GetValue<string>("target") ?? "https://foo.bar")
         )
         {
             IsRequired = true,

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -56,7 +56,7 @@ public static partial class Program
             aliases: new string[] { "--target", "-t" },
             description: "target NPM registry to publish to",
             getDefaultValue: () =>
-                new Uri(Configuration.GetSection(kDefaultsSection).GetValue<string>("target") ?? "https://foo.bar")
+                new Uri(Configuration.GetSection(kDefaultsSection).GetValue<string>(kTargetKey) ?? "https://foo.bar")
         )
         {
             IsRequired = true,

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -28,7 +28,7 @@ public static partial class Program
             aliases: new string[] { "--prerelease-suffix", },
             description: "version prerelease suffix ('foobar' -> '1.2.3-foobar+buildmeta)",
             getDefaultValue: () =>
-                Configuration.GetSection(kDefaultsSection).GetValue<string>("prerelease-suffix") ?? string.Empty
+                Configuration.GetSection(kDefaultsSection).GetValue<string>(kPrereleaseSuffixKey) ?? string.Empty
         );
 
     private static Option<string> UpmBuildmetaSuffixOption =

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -17,7 +17,7 @@ public static partial class Program
         new(
             aliases: new string[] { "--unity", "-u" },
             description: "minimum Unity version required by package.json",
-            getDefaultValue: () => Configuration.GetSection("default").GetValue<string>("unity") ?? "2022.3" //< latest LTS
+            getDefaultValue: () => Configuration.GetSection(kDefaultsSection).GetValue<string>("unity") ?? "2022.3" //< latest LTS
         )
         {
             IsRequired = true,
@@ -28,7 +28,7 @@ public static partial class Program
             aliases: new string[] { "--prerelease-suffix", },
             description: "version prerelease suffix ('foobar' -> '1.2.3-foobar+buildmeta)",
             getDefaultValue: () =>
-                Configuration.GetSection("default").GetValue<string>("prerelease-suffix") ?? string.Empty
+                Configuration.GetSection(kDefaultsSection).GetValue<string>("prerelease-suffix") ?? string.Empty
         );
 
     private static Option<string> UpmBuildmetaSuffixOption =
@@ -36,7 +36,7 @@ public static partial class Program
             aliases: new string[] { "--buildmeta-suffix", },
             description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)",
             getDefaultValue: () =>
-                Configuration.GetSection("default").GetValue<string>("buildmeta-suffix") ?? string.Empty
+                Configuration.GetSection(kDefaultsSection).GetValue<string>("buildmeta-suffix") ?? string.Empty
         );
 
     private static Option<string> UpmTokenOption =

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -17,7 +17,7 @@ public static partial class Program
         new(
             aliases: new string[] { "--unity", "-u" },
             description: "minimum Unity version required by package.json",
-            getDefaultValue: () => Configuration.GetSection(kDefaultsSection).GetValue<string>("unity") ?? "2022.3" //< latest LTS
+            getDefaultValue: () => Configuration.GetSection(kDefaultsSection).GetValue<string>(kUnityKey) ?? "2022.3" //< latest LTS
         )
         {
             IsRequired = true,

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -36,7 +36,7 @@ public static partial class Program
             aliases: new string[] { "--buildmeta-suffix", },
             description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)",
             getDefaultValue: () =>
-                Configuration.GetSection(kDefaultsSection).GetValue<string>("buildmeta-suffix") ?? string.Empty
+                Configuration.GetSection(kDefaultsSection).GetValue<string>(kBuildmetaSuffixKey) ?? string.Empty
         );
 
     private static Option<string> UpmTokenOption =


### PR DESCRIPTION
- refactor (NuGettier): use constant string for 'defaults' section key
- refactor (NuGettier): use constant string for 'output-direction' value key
- refactor (NuGettier): use constant string for 'target' value key
- refactor (NuGettier): use constant string for 'unity' value key
- refactor (NuGettier): use constant string for 'prerelease-suffix' value key
- refactor (NuGettier): use constant string for 'buildmeta-suffix' value key
