### PR TITLE
refactor (NuGettier): split tool project into 'dotnet-nugettier' and 'nugettier'

### DIFF
--- a/DotnetNugettier/DotnetNugettier.csproj
+++ b/DotnetNugettier/DotnetNugettier.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="build settings">
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <IsTool>true</IsTool>
+  </PropertyGroup>
+
+  <PropertyGroup Label="packaging settings">
+    <!-- required for packing .netconfig -->
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+  </PropertyGroup>
+
+  <PropertyGroup Label="version metadata">
+    <Version>0.1.17</Version>
+    <AssemblyVersion>0.1.17.120</AssemblyVersion>
+    <FileVersion>0.1.17.416</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="project metadata">
+    <Title>DontnetNuGettier</Title>
+    <Description>A dotnet extension to quey nuget packages with integrated support for Unity package creation.</Description>
+    <PackageTags>NuGet;npm;upm;unity</PackageTags>
+    <PackageIcon>Icon.png</PackageIcon>
+    <PackageIconUrl>https://raw.github.com/kagekirin/NuGettier/main/NuGettier/Icon.png</PackageIconUrl>
+  </PropertyGroup>
+
+  <PropertyGroup Label="tool metadata">
+    <ToolCommandName>dotnet-nugettier</ToolCommandName>
+  </PropertyGroup>
+
+</Project>

--- a/DotnetNugettier/Program.cs
+++ b/DotnetNugettier/Program.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+
+#nullable enable
+
+namespace DotnetNugettier;
+
+public static partial class Program
+{
+    static async Task<int> Main(string[] args)
+    {
+        try
+        {
+            CancellationTokenSource cancellationTokenSource = new();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            using var process = new System.Diagnostics.Process();
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.FileName = @"nugettier";
+            process.StartInfo.WorkingDirectory = Environment.CurrentDirectory;
+            process.StartInfo.Arguments = string.Join(" ", args);
+
+            process.Start();
+            await process.WaitForExitAsync(cancellationToken);
+            var exitCode = process.ExitCode;
+            var stdout = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+
+            if (!string.IsNullOrEmpty(stdout))
+                Console.WriteLine(stdout);
+
+            if (!string.IsNullOrEmpty(stderr))
+                Console.Error.WriteLine(stderr);
+
+            return exitCode;
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine(e.Message);
+            return 1;
+        }
+    }
+}

--- a/NuGettier.sln
+++ b/NuGettier.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGettier.Upm", "NuGettier.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGettier.Amalgamate", "NuGettier.Amalgamate\NuGettier.Amalgamate.csproj", "{D37C2BDC-9BAF-41B1-B711-0438DBEB6AA4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotnetNugettier", "DotnetNugettier\DotnetNugettier.csproj", "{5C5EE053-0D2A-4C23-89FA-2FE5B900DCEC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,5 +44,9 @@ Global
 		{D37C2BDC-9BAF-41B1-B711-0438DBEB6AA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D37C2BDC-9BAF-41B1-B711-0438DBEB6AA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D37C2BDC-9BAF-41B1-B711-0438DBEB6AA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C5EE053-0D2A-4C23-89FA-2FE5B900DCEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C5EE053-0D2A-4C23-89FA-2FE5B900DCEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C5EE053-0D2A-4C23-89FA-2FE5B900DCEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C5EE053-0D2A-4C23-89FA-2FE5B900DCEC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="tool metadata">
-    <ToolCommandName>dotnet-nugettier</ToolCommandName>
+    <ToolCommandName>nugettier</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup Label="package dependencies">


### PR DESCRIPTION
- build (NuGettier): rename tool command name to 'nugettier'
- feature: add DotnetNugettier project
- feature (DotnetNugettier): implement 'dotnet-nugettier' as simple shim around 'nugettier'
