### PR TITLE
build: update dependencies

### DIFF
--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
     <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.Text.Json" Version="8.0.0"/>
-    <PackageReference Include="Xunit" Version="2.5.3"/>
+    <PackageReference Include="Xunit" Version="2.6.4"/>
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -27,7 +27,7 @@
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
     <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
-    <PackageReference Include="System.Text.Json" Version="7.0.3"/>
+    <PackageReference Include="System.Text.Json" Version="8.0.0"/>
     <PackageReference Include="Xunit" Version="2.5.3"/>
   </ItemGroup>
 

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="NuGet.Resolver" Version="6.8.0"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
-    <PackageReference Include="Xunit" Version="2.5.3"/>
+    <PackageReference Include="Xunit" Version="2.6.4"/>
   </ItemGroup>
 
   <ItemGroup Label="packaged files">

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
     <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="package dependencies">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
     <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -28,7 +28,7 @@
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
     <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
-    <PackageReference Include="System.Text.Json" Version="7.0.3"/>
+    <PackageReference Include="System.Text.Json" Version="8.0.0"/>
     <PackageReference Include="Xunit" Version="2.5.3"/>
   </ItemGroup>
 

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.Text.Json" Version="8.0.0"/>
-    <PackageReference Include="Xunit" Version="2.5.3"/>
+    <PackageReference Include="Xunit" Version="2.6.4"/>
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4"/>
     <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="NuGet.Resolver" Version="6.8.0"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
-    <PackageReference Include="Xunit" Version="2.5.3"/>
+    <PackageReference Include="Xunit" Version="2.6.4"/>
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -34,7 +34,7 @@
   <ItemGroup Label="package dependencies">
     <PackageReference Include="DotNetConfig" Version="1.0.6"/>
     <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>


### PR DESCRIPTION
- build (NuGettier): bump dependency on Microsoft.Extensions.Configuration to v8.0.0
- build (NuGettier): bump dependency on Xunit to v2.6.4
- build (NuGettier.Core): bump dependency on Microsoft.Extensions.Configuration to v8.0.0
- build (NuGettier.Core): bump dependency on Microsoft.Extensions.Configuration.Binder to v8.0.0
- build (NuGettier.Core): bump dependency on Xunit to v2.6.4
- build (NuGettier.Upm): bump dependency on Microsoft.Extensions.Configuration to v8.0.0
- build (NuGettier.Upm): bump dependency on Microsoft.Extensions.Configuration.Binder to v8.0.0
- build (NuGettier.Upm): bump dependency on System.Text.Json to v8.0.0
- build (NuGettier.Upm): bump dependency on Xunit to v2.6.4
- build (NuGettier.Amalgamate): bump dependency on Microsoft.Extensions.Configuration to v8.0.0
- build (NuGettier.Amalgamate): bump dependency on Microsoft.Extensions.Configuration.Binder to v8.0.0
- build (NuGettier.Amalgamate): bump dependency on System.Text.Json to v8.0.0
- build (NuGettier.Amalgamate): bump dependency on Xunit to v2.6.4
