### PR TITLE
refactor (NuGettier): change main class Program into non-static class and adapt related methods accordingly

### DIFF
--- a/NuGettier/Arguments.cs
+++ b/NuGettier/Arguments.cs
@@ -5,8 +5,8 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Argument<string> PackageIdArgument = new("packageId", "complete and exact package id");
-    private static Argument<string> PackageIdVersionArgument =
+    private Argument<string> PackageIdArgument = new("packageId", "complete and exact package id");
+    private Argument<string> PackageIdVersionArgument =
         new("packageIdVersion", "package.id[@version | @latest]");
-    private static Argument<string> SearchTermArgument = new("searchTerm", "package id-ish or search term");
+    private Argument<string> SearchTermArgument = new("searchTerm", "package id-ish or search term");
 }

--- a/NuGettier/Arguments.cs
+++ b/NuGettier/Arguments.cs
@@ -3,7 +3,7 @@ using System.CommandLine;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Argument<string> PackageIdArgument = new("packageId", "complete and exact package id");
     private static Argument<string> PackageIdVersionArgument =

--- a/NuGettier/Constants.cs
+++ b/NuGettier/Constants.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     const string kDefaultsSection = "defaults";
     const string kOutputDirectoryKey = "output-directory";

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -22,7 +22,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command GetCommand =>
         new Command("get", "download the given NuPkg at the given version")

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -33,7 +33,7 @@ public partial class Program
             OutputDirectoryOption,
         }.WithHandler(CommandHandler.Create(Get));
 
-    private static async Task<int> Get(
+    private async Task<int> Get(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -24,7 +24,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command GetCommand =>
+    private Command GetCommand =>
         new Command("get", "download the given NuPkg at the given version")
         {
             PackageIdVersionArgument,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -32,7 +32,7 @@ public partial class Program
             SourceRepositoriesOption,
         }.WithHandler(CommandHandler.Create(Info));
 
-    private static async Task<int> Info(
+    private async Task<int> Info(
         string packageIdVersion,
         bool preRelease,
         bool json,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -22,7 +22,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command InfoCommand =>
+    private Command InfoCommand =>
         new Command("info", "retrieve information about a specific version of a given package")
         {
             PackageIdVersionArgument,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command InfoCommand =>
         new Command("info", "retrieve information about a specific version of a given package")

--- a/NuGettier/CoreActions/List.cs
+++ b/NuGettier/CoreActions/List.cs
@@ -32,7 +32,7 @@ public partial class Program
             SourceRepositoriesOption,
         }.WithHandler(CommandHandler.Create(List));
 
-    private static async Task<int> List(
+    private async Task<int> List(
         string packageId,
         bool preRelease,
         bool json,

--- a/NuGettier/CoreActions/List.cs
+++ b/NuGettier/CoreActions/List.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command ListCommand =>
         new Command("list", "list available version for a given package")

--- a/NuGettier/CoreActions/List.cs
+++ b/NuGettier/CoreActions/List.cs
@@ -22,7 +22,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command ListCommand =>
+    private Command ListCommand =>
         new Command("list", "list available version for a given package")
         {
             PackageIdArgument,

--- a/NuGettier/CoreActions/ListDependencies.cs
+++ b/NuGettier/CoreActions/ListDependencies.cs
@@ -23,7 +23,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command ListDependenciesCommand =>
+    private Command ListDependenciesCommand =>
         new Command("deps", "retrieve information about a specific version of a given package")
         {
             PackageIdVersionArgument,

--- a/NuGettier/CoreActions/ListDependencies.cs
+++ b/NuGettier/CoreActions/ListDependencies.cs
@@ -21,7 +21,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command ListDependenciesCommand =>
         new Command("deps", "retrieve information about a specific version of a given package")

--- a/NuGettier/CoreActions/ListDependencies.cs
+++ b/NuGettier/CoreActions/ListDependencies.cs
@@ -33,7 +33,7 @@ public partial class Program
             SourceRepositoriesOption,
         }.WithHandler(CommandHandler.Create(ListDependencies));
 
-    private static async Task<int> ListDependencies(
+    private async Task<int> ListDependencies(
         string packageIdVersion,
         bool preRelease,
         bool json,

--- a/NuGettier/CoreActions/Search.cs
+++ b/NuGettier/CoreActions/Search.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command SearchCommand =>
         new Command("search", "search for term or package id")

--- a/NuGettier/CoreActions/Search.cs
+++ b/NuGettier/CoreActions/Search.cs
@@ -31,7 +31,7 @@ public partial class Program
             SourceRepositoriesOption,
         }.WithHandler(CommandHandler.Create(Search));
 
-    private static async Task<int> Search(
+    private async Task<int> Search(
         string searchTerm,
         bool json,
         bool @short,

--- a/NuGettier/CoreActions/Search.cs
+++ b/NuGettier/CoreActions/Search.cs
@@ -22,7 +22,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command SearchCommand =>
+    private Command SearchCommand =>
         new Command("search", "search for term or package id")
         {
             SearchTermArgument,

--- a/NuGettier/Extensions/CommandWithHandler.cs
+++ b/NuGettier/Extensions/CommandWithHandler.cs
@@ -17,7 +17,7 @@ internal static class CommandWithHandlerExtension
 
     public static Command WithHandler(this Command command, string methodName)
     {
-        var method = typeof(Program).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+        var method = typeof(Program).GetMethod(methodName, BindingFlags.NonPublic);
         return command.WithHandler(CommandHandler.Create(method!));
     }
 }

--- a/NuGettier/JsonSerializerOptions.cs
+++ b/NuGettier/JsonSerializerOptions.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true, };
 }

--- a/NuGettier/JsonSerializerOptions.cs
+++ b/NuGettier/JsonSerializerOptions.cs
@@ -6,5 +6,5 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true, };
+    private readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true, };
 }

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -13,19 +13,19 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Option<bool> OutputJsonOption =
+    private Option<bool> OutputJsonOption =
         new(aliases: ["--json", "-j"], description: "whether to output result as JSON (for piping into `jq` etc)");
 
-    private static Option<bool> ShortOutputOption =
+    private Option<bool> ShortOutputOption =
         new(aliases: ["--short", "-ß"], description: "whether to shorten output to the essential");
 
-    private static Option<bool> IncludePrereleaseOption =
+    private Option<bool> IncludePrereleaseOption =
         new(aliases: ["--preRelease", "-p"], description: "whether to include prerelease versions");
 
-    private static Option<bool> IncludeDependenciesOption =
+    private Option<bool> IncludeDependenciesOption =
         new(aliases: ["--includeDependencies", "-i"], description: "whether to include dependencies");
 
-    private static Option<DirectoryInfo> OutputDirectoryOption =
+    private Option<DirectoryInfo> OutputDirectoryOption =
         new(
             aliases: ["--outputDirectory", "-o"],
             description: "directory to output files to",
@@ -39,7 +39,7 @@ public partial class Program
             IsRequired = true,
         };
 
-    private static Option<Uri[]> SourceRepositoriesOption =
+    private Option<Uri[]> SourceRepositoriesOption =
         new(aliases: ["--source", "-s"], description: "source NuGet repositories to fetch from")
         {
             Name = "sources",
@@ -48,7 +48,7 @@ public partial class Program
             Arity = ArgumentArity.OneOrMore,
         };
 
-    private static Option<Uri> TargetRegistryOption =
+    private Option<Uri> TargetRegistryOption =
         new(
             aliases: ["--target", "-t"],
             description: "target NPM registry to publish to",

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Option<bool> OutputJsonOption =
         new(aliases: ["--json", "-j"], description: "whether to output result as JSON (for piping into `jq` etc)");

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static IConfigurationRoot? configurationRoot = null;
     private static IConfigurationRoot Configuration

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -28,7 +28,7 @@ public partial class Program
         }
     }
 
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+    private readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     async Task<int> Main(string[] args)
     {

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -30,7 +30,7 @@ public partial class Program
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    static async Task<int> Main(string[] args)
+    async Task<int> Main(string[] args)
     {
         LogManager
             .Setup()

--- a/NuGettier/UpmActions/Upm.cs
+++ b/NuGettier/UpmActions/Upm.cs
@@ -12,7 +12,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command UpmCommand =>
+    private Command UpmCommand =>
         new Command("upm", "root command for a number of commands specific to Unity packages")
         {
             UpmInfoCommand,

--- a/NuGettier/UpmActions/Upm.cs
+++ b/NuGettier/UpmActions/Upm.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command UpmCommand =>
         new Command("upm", "root command for a number of commands specific to Unity packages")

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -40,7 +40,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmInfo));
 
-    private static async Task<int> UpmInfo(
+    private async Task<int> UpmInfo(
         string packageIdVersion,
         bool json,
         bool preRelease,

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -25,7 +25,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command UpmInfoCommand =>
+    private Command UpmInfoCommand =>
         new Command("info", "preview Unity package informations for the given NuPkg at the given version")
         {
             PackageIdVersionArgument,

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command UpmInfoCommand =>
         new Command("info", "preview Unity package informations for the given NuPkg at the given version")

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -41,7 +41,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmPack));
 
-    private static async Task<int> UpmPack(
+    private async Task<int> UpmPack(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command UpmPackCommand =>
         new Command("pack", "repack the given NuPkg at the given version as Unity package")

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -26,7 +26,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command UpmPackCommand =>
+    private Command UpmPackCommand =>
         new Command("pack", "repack the given NuPkg at the given version as Unity package")
         {
             PackageIdVersionArgument,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -31,7 +31,7 @@ public partial class Program
             UpmPackageAccessLevel,
         }.WithHandler(CommandHandler.Create(UpmPublish));
 
-    private static async Task<int> UpmPublish(
+    private async Task<int> UpmPublish(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command UpmPublishCommand =>
         new Command("publish", "repack the given NuPkg at the given version as Unity package and publish")

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -13,7 +13,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command UpmPublishCommand =>
+    private Command UpmPublishCommand =>
         new Command("publish", "repack the given NuPkg at the given version as Unity package and publish")
         {
             PackageIdVersionArgument,

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command UpmUnpackCommand =>
         new Command("unpack", "same as `upm pack`, but writing the unpacked files to the output directory")

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -26,7 +26,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command UpmUnpackCommand =>
+    private Command UpmUnpackCommand =>
         new Command("unpack", "same as `upm pack`, but writing the unpacked files to the output directory")
         {
             PackageIdVersionArgument,

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -41,7 +41,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmUnpack));
 
-    private static async Task<int> UpmUnpack(
+    private async Task<int> UpmUnpack(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmAmalgamateActions/Amalgamate.cs
+++ b/NuGettier/UpmAmalgamateActions/Amalgamate.cs
@@ -12,7 +12,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command AmalgamateCommand =>
+    private Command AmalgamateCommand =>
         new Command("amalgamate", "root command for a number of commands specific to amalgamated Unity packages")
         {
             AmalgamateInfoCommand,

--- a/NuGettier/UpmAmalgamateActions/Amalgamate.cs
+++ b/NuGettier/UpmAmalgamateActions/Amalgamate.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command AmalgamateCommand =>
         new Command("amalgamate", "root command for a number of commands specific to amalgamated Unity packages")

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -25,7 +25,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command AmalgamateInfoCommand =>
+    private Command AmalgamateInfoCommand =>
         new Command("info", "preview Unity package informations for the given NuPkg at the given version")
         {
             PackageIdVersionArgument,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -40,7 +40,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(AmalgamateInfo));
 
-    private static async Task<int> AmalgamateInfo(
+    private async Task<int> AmalgamateInfo(
         string packageIdVersion,
         bool json,
         bool preRelease,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command AmalgamateInfoCommand =>
         new Command("info", "preview Unity package informations for the given NuPkg at the given version")

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -25,7 +25,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command AmalgamatePackCommand =>
+    private Command AmalgamatePackCommand =>
         new Command("pack", "repack the given NuPkg at the given version as Unity package")
         {
             PackageIdVersionArgument,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command AmalgamatePackCommand =>
         new Command("pack", "repack the given NuPkg at the given version as Unity package")

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -40,7 +40,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(AmalgamatePack));
 
-    private static async Task<int> AmalgamatePack(
+    private async Task<int> AmalgamatePack(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -13,7 +13,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command AmalgamatePublishCommand =>
+    private Command AmalgamatePublishCommand =>
         new Command("publish", "repack the given NuPkg at the given version as Unity package and publish")
         {
             PackageIdVersionArgument,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -31,7 +31,7 @@ public partial class Program
             UpmPackageAccessLevel,
         }.WithHandler(CommandHandler.Create(AmalgamatePublish));
 
-    private static async Task<int> AmalgamatePublish(
+    private async Task<int> AmalgamatePublish(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command AmalgamatePublishCommand =>
         new Command("publish", "repack the given NuPkg at the given version as Unity package and publish")

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -40,7 +40,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(AmalgamateUnpack));
 
-    private static async Task<int> AmalgamateUnpack(
+    private async Task<int> AmalgamateUnpack(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -25,7 +25,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Command AmalgamateUnpackCommand =>
+    private Command AmalgamateUnpackCommand =>
         new Command("unpack", "same as `upm pack`, but writing the unpacked files to the output directory")
         {
             PackageIdVersionArgument,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Command AmalgamateUnpackCommand =>
         new Command("unpack", "same as `upm pack`, but writing the unpacked files to the output directory")

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -13,7 +13,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private static Option<string> UpmUnityVersionOption =
+    private Option<string> UpmUnityVersionOption =
         new(
             aliases: ["--unity", "-u"],
             description: "minimum Unity version required by package.json",
@@ -23,7 +23,7 @@ public partial class Program
             IsRequired = true,
         };
 
-    private static Option<string> UpmPrereleaseSuffixOption =
+    private Option<string> UpmPrereleaseSuffixOption =
         new(
             aliases: ["--prerelease-suffix",],
             description: "version prerelease suffix ('foobar' -> '1.2.3-foobar+buildmeta)",
@@ -31,7 +31,7 @@ public partial class Program
                 Configuration.GetSection(kDefaultsSection).GetValue<string>(kPrereleaseSuffixKey) ?? string.Empty
         );
 
-    private static Option<string> UpmBuildmetaSuffixOption =
+    private Option<string> UpmBuildmetaSuffixOption =
         new(
             aliases: ["--buildmeta-suffix",],
             description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)",
@@ -39,33 +39,33 @@ public partial class Program
                 Configuration.GetSection(kDefaultsSection).GetValue<string>(kBuildmetaSuffixKey) ?? string.Empty
         );
 
-    private static Option<string> UpmTokenOption =
+    private Option<string> UpmTokenOption =
         new(aliases: ["--token",], description: "authentication token required to connect to NPM server")
         {
             IsRequired = false,
         };
 
-    private static Option<string> UpmNpmrcOption =
+    private Option<string> UpmNpmrcOption =
         new(aliases: ["--npmrc",], description: "path to existing .npmrc required to connect to NPM server")
         {
             IsRequired = false,
         };
 
-    private static Option<Uri> UpmRepositoryUrlOption =
+    private Option<Uri> UpmRepositoryUrlOption =
         new(aliases: ["--repository",], description: "NPM package repository URL, assigned to `{.repository.url`}")
         {
             IsRequired = false,
         };
 
-    private static Option<string> UpmDirectoryUrlOption =
+    private Option<string> UpmDirectoryUrlOption =
         new(aliases: ["--directory",], description: "NPM package directory path, assigned to `{.repository.directory`}")
         {
             IsRequired = false,
         };
 
-    private static Option<bool> UpmDryRunOption = new(aliases: ["--dry-run", "-n"], description: "Dry run");
+    private Option<bool> UpmDryRunOption = new(aliases: ["--dry-run", "-n"], description: "Dry run");
 
-    private static Option<Upm.PackageAccessLevel> UpmPackageAccessLevel =
+    private Option<Upm.PackageAccessLevel> UpmPackageAccessLevel =
         new(
             aliases: ["--access", "-a",],
             //getDefaultValue => Upm.PackageAccessLevel.Public,

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace NuGettier;
 
-public static partial class Program
+public partial class Program
 {
     private static Option<string> UpmUnityVersionOption =
         new(


### PR DESCRIPTION
- refactor (NuGettier): change main class 'Program' into a regular, non-static class
- refactor (NuGettier): change Program.Main into a regular, non-static method
- refactor (NuGettier): change Program.Logger into a regular, non-static property
- refactor (NuGettier): change all Option<> instances in Program into regular, non-static properties
- refactor (NuGettier): change all Argument<> instances in Program into regular, non-static properties
- refactor (NuGettier): change Program.JsonOptions into a regular, non-static property
- refactor (NuGettier): change Program.GetCommand into a regular, non-static property
- refactor (NuGettier): change Program.InfoCommand into a regular, non-static property
- refactor (NuGettier): change Program.ListCommand into a regular, non-static property
- refactor (NuGettier): change Program.ListDependenciesCommand into a regular, non-static property
- refactor (NuGettier): change Program.SearchCommand into a regular, non-static property
- refactor (NuGettier): change Program.UpmCommand into a regular, non-static property
- refactor (NuGettier): change Program.UpmInfoCommand into a regular, non-static property
- refactor (NuGettier): change Program.UpmPackCommand into a regular, non-static property
- refactor (NuGettier): change Program.UpmPublishCommand into a regular, non-static property
- refactor (NuGettier): change Program.UpmUnpackCommand into a regular, non-static property
- refactor (NuGettier): change Program.AmalgamateCommand into a regular, non-static property
- refactor (NuGettier): change Program.AmalgamateInfoCommand into a regular, non-static property
- refactor (NuGettier): change Program.AmalgamatePackCommand into a regular, non-static property
- refactor (NuGettier): change Program.AmalgamatePublishCommand into a regular, non-static property
- refactor (NuGettier): change Program.AmalgamateUnpackCommand into a regular, non-static property
- refactor (NuGettier): change command handler Program.Get() into a regular, non-static method
- refactor (NuGettier): change command handler Program.Info() into a regular, non-static method
- refactor (NuGettier): change command handler Program.List() into a regular, non-static method
- refactor (NuGettier): change command handler Program.ListDependencies() into a regular, non-static method
- refactor (NuGettier): change command handler Program.Search() into a regular, non-static method
- refactor (NuGettier): change command handler Program.UpmInfo() into a regular, non-static method
- refactor (NuGettier): change command handler Program.UpmPack() into a regular, non-static method
- refactor (NuGettier): change command handler Program.UpmPublish() into a regular, non-static method
- refactor (NuGettier): change command handler Program.UpmUnpack() into a regular, non-static method
- refactor (NuGettier): change command handler Program.AmalgamateInfo() into a regular, non-static method
- refactor (NuGettier): change command handler Program.AmalgamatePack() into a regular, non-static method
- refactor (NuGettier): change command handler Program.AmalgamatePublish() into a regular, non-static method
- refactor (NuGettier): change command handler Program.AmalgamateUnpack() into a regular, non-static method
- refactor (NuGettier): adapt Command.WithHandler() extension method to take non-static methods
