### PR TITLE
refactor (NuGettier): revert back to static method Program.Main() and related related static methods/properties

### DIFF
--- a/NuGettier/Arguments.cs
+++ b/NuGettier/Arguments.cs
@@ -5,8 +5,8 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Argument<string> PackageIdArgument = new("packageId", "complete and exact package id");
-    private Argument<string> PackageIdVersionArgument =
+    private static Argument<string> PackageIdArgument = new("packageId", "complete and exact package id");
+    private static Argument<string> PackageIdVersionArgument =
         new("packageIdVersion", "package.id[@version | @latest]");
-    private Argument<string> SearchTermArgument = new("searchTerm", "package id-ish or search term");
+    private static Argument<string> SearchTermArgument = new("searchTerm", "package id-ish or search term");
 }

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -24,7 +24,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command GetCommand =>
+    private static Command GetCommand =>
         new Command("get", "download the given NuPkg at the given version")
         {
             PackageIdVersionArgument,
@@ -33,7 +33,7 @@ public partial class Program
             OutputDirectoryOption,
         }.WithHandler(CommandHandler.Create(Get));
 
-    private async Task<int> Get(
+    private static async Task<int> Get(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -22,7 +22,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command InfoCommand =>
+    private static Command InfoCommand =>
         new Command("info", "retrieve information about a specific version of a given package")
         {
             PackageIdVersionArgument,
@@ -32,7 +32,7 @@ public partial class Program
             SourceRepositoriesOption,
         }.WithHandler(CommandHandler.Create(Info));
 
-    private async Task<int> Info(
+    private static async Task<int> Info(
         string packageIdVersion,
         bool preRelease,
         bool json,

--- a/NuGettier/CoreActions/List.cs
+++ b/NuGettier/CoreActions/List.cs
@@ -22,7 +22,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command ListCommand =>
+    private static Command ListCommand =>
         new Command("list", "list available version for a given package")
         {
             PackageIdArgument,
@@ -32,7 +32,7 @@ public partial class Program
             SourceRepositoriesOption,
         }.WithHandler(CommandHandler.Create(List));
 
-    private async Task<int> List(
+    private static async Task<int> List(
         string packageId,
         bool preRelease,
         bool json,

--- a/NuGettier/CoreActions/ListDependencies.cs
+++ b/NuGettier/CoreActions/ListDependencies.cs
@@ -23,7 +23,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command ListDependenciesCommand =>
+    private static Command ListDependenciesCommand =>
         new Command("deps", "retrieve information about a specific version of a given package")
         {
             PackageIdVersionArgument,
@@ -33,7 +33,7 @@ public partial class Program
             SourceRepositoriesOption,
         }.WithHandler(CommandHandler.Create(ListDependencies));
 
-    private async Task<int> ListDependencies(
+    private static async Task<int> ListDependencies(
         string packageIdVersion,
         bool preRelease,
         bool json,

--- a/NuGettier/CoreActions/Search.cs
+++ b/NuGettier/CoreActions/Search.cs
@@ -22,7 +22,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command SearchCommand =>
+    private static Command SearchCommand =>
         new Command("search", "search for term or package id")
         {
             SearchTermArgument,
@@ -31,7 +31,7 @@ public partial class Program
             SourceRepositoriesOption,
         }.WithHandler(CommandHandler.Create(Search));
 
-    private async Task<int> Search(
+    private static async Task<int> Search(
         string searchTerm,
         bool json,
         bool @short,

--- a/NuGettier/Extensions/CommandWithHandler.cs
+++ b/NuGettier/Extensions/CommandWithHandler.cs
@@ -17,7 +17,7 @@ internal static class CommandWithHandlerExtension
 
     public static Command WithHandler(this Command command, string methodName)
     {
-        var method = typeof(Program).GetMethod(methodName, BindingFlags.NonPublic);
+        var method = typeof(Program).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
         return command.WithHandler(CommandHandler.Create(method!));
     }
 }

--- a/NuGettier/JsonSerializerOptions.cs
+++ b/NuGettier/JsonSerializerOptions.cs
@@ -6,5 +6,5 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true, };
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true, };
 }

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -13,19 +13,19 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Option<bool> OutputJsonOption =
+    private static Option<bool> OutputJsonOption =
         new(aliases: ["--json", "-j"], description: "whether to output result as JSON (for piping into `jq` etc)");
 
-    private Option<bool> ShortOutputOption =
+    private static Option<bool> ShortOutputOption =
         new(aliases: ["--short", "-ß"], description: "whether to shorten output to the essential");
 
-    private Option<bool> IncludePrereleaseOption =
+    private static Option<bool> IncludePrereleaseOption =
         new(aliases: ["--preRelease", "-p"], description: "whether to include prerelease versions");
 
-    private Option<bool> IncludeDependenciesOption =
+    private static Option<bool> IncludeDependenciesOption =
         new(aliases: ["--includeDependencies", "-i"], description: "whether to include dependencies");
 
-    private Option<DirectoryInfo> OutputDirectoryOption =
+    private static Option<DirectoryInfo> OutputDirectoryOption =
         new(
             aliases: ["--outputDirectory", "-o"],
             description: "directory to output files to",
@@ -39,7 +39,7 @@ public partial class Program
             IsRequired = true,
         };
 
-    private Option<Uri[]> SourceRepositoriesOption =
+    private static Option<Uri[]> SourceRepositoriesOption =
         new(aliases: ["--source", "-s"], description: "source NuGet repositories to fetch from")
         {
             Name = "sources",
@@ -48,7 +48,7 @@ public partial class Program
             Arity = ArgumentArity.OneOrMore,
         };
 
-    private Option<Uri> TargetRegistryOption =
+    private static Option<Uri> TargetRegistryOption =
         new(
             aliases: ["--target", "-t"],
             description: "target NPM registry to publish to",

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -28,9 +28,9 @@ public partial class Program
         }
     }
 
-    private readonly Logger Logger = LogManager.GetCurrentClassLogger();
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    async Task<int> Main(string[] args)
+    static async Task<int> Main(string[] args)
     {
         LogManager
             .Setup()

--- a/NuGettier/UpmActions/Upm.cs
+++ b/NuGettier/UpmActions/Upm.cs
@@ -12,7 +12,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command UpmCommand =>
+    private static Command UpmCommand =>
         new Command("upm", "root command for a number of commands specific to Unity packages")
         {
             UpmInfoCommand,

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -25,7 +25,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command UpmInfoCommand =>
+    private static Command UpmInfoCommand =>
         new Command("info", "preview Unity package informations for the given NuPkg at the given version")
         {
             PackageIdVersionArgument,
@@ -40,7 +40,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmInfo));
 
-    private async Task<int> UpmInfo(
+    private static async Task<int> UpmInfo(
         string packageIdVersion,
         bool json,
         bool preRelease,

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -26,7 +26,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command UpmPackCommand =>
+    private static Command UpmPackCommand =>
         new Command("pack", "repack the given NuPkg at the given version as Unity package")
         {
             PackageIdVersionArgument,
@@ -41,7 +41,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmPack));
 
-    private async Task<int> UpmPack(
+    private static async Task<int> UpmPack(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -13,7 +13,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command UpmPublishCommand =>
+    private static Command UpmPublishCommand =>
         new Command("publish", "repack the given NuPkg at the given version as Unity package and publish")
         {
             PackageIdVersionArgument,
@@ -31,7 +31,7 @@ public partial class Program
             UpmPackageAccessLevel,
         }.WithHandler(CommandHandler.Create(UpmPublish));
 
-    private async Task<int> UpmPublish(
+    private static async Task<int> UpmPublish(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -26,7 +26,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command UpmUnpackCommand =>
+    private static Command UpmUnpackCommand =>
         new Command("unpack", "same as `upm pack`, but writing the unpacked files to the output directory")
         {
             PackageIdVersionArgument,
@@ -41,7 +41,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(UpmUnpack));
 
-    private async Task<int> UpmUnpack(
+    private static async Task<int> UpmUnpack(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmAmalgamateActions/Amalgamate.cs
+++ b/NuGettier/UpmAmalgamateActions/Amalgamate.cs
@@ -12,7 +12,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command AmalgamateCommand =>
+    private static Command AmalgamateCommand =>
         new Command("amalgamate", "root command for a number of commands specific to amalgamated Unity packages")
         {
             AmalgamateInfoCommand,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -25,7 +25,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command AmalgamateInfoCommand =>
+    private static Command AmalgamateInfoCommand =>
         new Command("info", "preview Unity package informations for the given NuPkg at the given version")
         {
             PackageIdVersionArgument,
@@ -40,7 +40,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(AmalgamateInfo));
 
-    private async Task<int> AmalgamateInfo(
+    private static async Task<int> AmalgamateInfo(
         string packageIdVersion,
         bool json,
         bool preRelease,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -25,7 +25,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command AmalgamatePackCommand =>
+    private static Command AmalgamatePackCommand =>
         new Command("pack", "repack the given NuPkg at the given version as Unity package")
         {
             PackageIdVersionArgument,
@@ -40,7 +40,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(AmalgamatePack));
 
-    private async Task<int> AmalgamatePack(
+    private static async Task<int> AmalgamatePack(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -13,7 +13,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command AmalgamatePublishCommand =>
+    private static Command AmalgamatePublishCommand =>
         new Command("publish", "repack the given NuPkg at the given version as Unity package and publish")
         {
             PackageIdVersionArgument,
@@ -31,7 +31,7 @@ public partial class Program
             UpmPackageAccessLevel,
         }.WithHandler(CommandHandler.Create(AmalgamatePublish));
 
-    private async Task<int> AmalgamatePublish(
+    private static async Task<int> AmalgamatePublish(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -25,7 +25,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Command AmalgamateUnpackCommand =>
+    private static Command AmalgamateUnpackCommand =>
         new Command("unpack", "same as `upm pack`, but writing the unpacked files to the output directory")
         {
             PackageIdVersionArgument,
@@ -40,7 +40,7 @@ public partial class Program
             UpmDirectoryUrlOption,
         }.WithHandler(CommandHandler.Create(AmalgamateUnpack));
 
-    private async Task<int> AmalgamateUnpack(
+    private static async Task<int> AmalgamateUnpack(
         string packageIdVersion,
         bool preRelease,
         IEnumerable<Uri> sources,

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -13,7 +13,7 @@ namespace NuGettier;
 
 public partial class Program
 {
-    private Option<string> UpmUnityVersionOption =
+    private static Option<string> UpmUnityVersionOption =
         new(
             aliases: ["--unity", "-u"],
             description: "minimum Unity version required by package.json",
@@ -23,7 +23,7 @@ public partial class Program
             IsRequired = true,
         };
 
-    private Option<string> UpmPrereleaseSuffixOption =
+    private static Option<string> UpmPrereleaseSuffixOption =
         new(
             aliases: ["--prerelease-suffix",],
             description: "version prerelease suffix ('foobar' -> '1.2.3-foobar+buildmeta)",
@@ -31,7 +31,7 @@ public partial class Program
                 Configuration.GetSection(kDefaultsSection).GetValue<string>(kPrereleaseSuffixKey) ?? string.Empty
         );
 
-    private Option<string> UpmBuildmetaSuffixOption =
+    private static Option<string> UpmBuildmetaSuffixOption =
         new(
             aliases: ["--buildmeta-suffix",],
             description: "version buildmeta suffix ('foobar' -> '1.2.3-prerelease+foobar)",
@@ -39,33 +39,33 @@ public partial class Program
                 Configuration.GetSection(kDefaultsSection).GetValue<string>(kBuildmetaSuffixKey) ?? string.Empty
         );
 
-    private Option<string> UpmTokenOption =
+    private static Option<string> UpmTokenOption =
         new(aliases: ["--token",], description: "authentication token required to connect to NPM server")
         {
             IsRequired = false,
         };
 
-    private Option<string> UpmNpmrcOption =
+    private static Option<string> UpmNpmrcOption =
         new(aliases: ["--npmrc",], description: "path to existing .npmrc required to connect to NPM server")
         {
             IsRequired = false,
         };
 
-    private Option<Uri> UpmRepositoryUrlOption =
+    private static Option<Uri> UpmRepositoryUrlOption =
         new(aliases: ["--repository",], description: "NPM package repository URL, assigned to `{.repository.url`}")
         {
             IsRequired = false,
         };
 
-    private Option<string> UpmDirectoryUrlOption =
+    private static Option<string> UpmDirectoryUrlOption =
         new(aliases: ["--directory",], description: "NPM package directory path, assigned to `{.repository.directory`}")
         {
             IsRequired = false,
         };
 
-    private Option<bool> UpmDryRunOption = new(aliases: ["--dry-run", "-n"], description: "Dry run");
+    private static Option<bool> UpmDryRunOption = new(aliases: ["--dry-run", "-n"], description: "Dry run");
 
-    private Option<Upm.PackageAccessLevel> UpmPackageAccessLevel =
+    private static Option<Upm.PackageAccessLevel> UpmPackageAccessLevel =
         new(
             aliases: ["--access", "-a",],
             //getDefaultValue => Upm.PackageAccessLevel.Public,


### PR DESCRIPTION
caveat: keep non-static Program class as this is required for the upcoming refactor towards Microsoft.Extensions.Logging.

This reverts commit 767e1946921a9471765f4626a3099dfc12cfed10. [#129]
