### PR TITLE
refactor: replace NLog logging with Microsoft.Extensions.Logging

### DIFF
--- a/NuGettier.Amalgamate/Context/Context.cs
+++ b/NuGettier.Amalgamate/Context/Context.cs
@@ -18,7 +18,8 @@ public partial class Context : Upm.Context
         Uri target,
         string? repository,
         string? directory,
-        IConsole console
+        IConsole console,
+        ILogger logger
     )
         : base(
             configuration: configuration,
@@ -27,7 +28,8 @@ public partial class Context : Upm.Context
             target: target,
             repository: repository,
             directory: directory,
-            console: console
+            console: console,
+            logger: logger
         ) { }
 
     public Context(Context other)

--- a/NuGettier.Amalgamate/Context/Context.cs
+++ b/NuGettier.Amalgamate/Context/Context.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
-using NLog;
+using Microsoft.Extensions.Logging;
 using NuGet.Protocol.Core.Types;
 using NuGettier;
 
@@ -11,8 +11,6 @@ namespace NuGettier.Amalgamate;
 
 public partial class Context : Upm.Context
 {
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-
     public Context(
         IConfigurationRoot configuration,
         IEnumerable<Uri> sources,

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
-    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
-using NLog;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -35,8 +35,6 @@ public partial class Context : IDisposable
 
     public record class BuildInfo(string AssemblyName, string AssemblyVersion);
 
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-
     public record class PackageRule(
         string Id,
         string Name,
@@ -54,6 +52,7 @@ public partial class Context : IDisposable
     public IConsole Console { get; protected set; }
     public BuildInfo Build { get; protected set; }
     public IEnumerable<PackageRule> PackageRules { get; protected set; }
+    protected readonly Microsoft.Extensions.Logging.ILogger Logger;
 
     public Context(IConfigurationRoot configuration, IEnumerable<Uri> sources, IConsole console)
     {

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -69,9 +69,9 @@ public partial class Context : IDisposable
 
         var entryAssembly = Assembly.GetEntryAssembly();
         var assemblyName = entryAssembly?.GetName();
-        Logger.Debug($"assembly name: {assemblyName?.Name}");
-        Logger.Debug($"assembly version: {assemblyName?.Version?.ToString(3)}");
-        Logger.Debug(
+        Logger.LogDebug($"assembly name: {assemblyName?.Name}");
+        Logger.LogDebug($"assembly version: {assemblyName?.Version?.ToString(3)}");
+        Logger.LogDebug(
             $"assembly informational version: {entryAssembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion}"
         );
 
@@ -104,7 +104,7 @@ public partial class Context : IDisposable
         Repositories = Sources.Select(source =>
         {
             var requestSource = source.GetComponents(UriComponents.HttpRequestUrl, UriFormat.UriEscaped);
-            Logger.Debug($"adding source {requestSource}");
+            Logger.LogDebug($"adding source {requestSource}");
             string? username = null;
             string? password = null;
             if (!string.IsNullOrEmpty(source.UserInfo))
@@ -112,8 +112,8 @@ public partial class Context : IDisposable
                 var userInfo = source.UserInfo.Split(':');
                 username = userInfo[0];
                 password = userInfo[1];
-                Logger.Debug($"\tusername: {username}");
-                Logger.Debug($"\tpassword: {password}");
+                Logger.LogDebug($"\tusername: {username}");
+                Logger.LogDebug($"\tpassword: {password}");
             }
             PackageSource packageSource =
                 new(requestSource, source.Authority)
@@ -137,7 +137,7 @@ public partial class Context : IDisposable
             .GetChildren()
             .Select(packageSection =>
             {
-                Logger.Debug($"package key: {packageSection.Key}");
+                Logger.LogDebug($"package key: {packageSection.Key}");
                 return new PackageRule(
                     Id: packageSection.Key,
                     Name: packageSection.GetValue<string>(kNameKey) ?? string.Empty,
@@ -152,7 +152,7 @@ public partial class Context : IDisposable
 
         foreach (var p in PackageRules)
         {
-            Logger.Debug($"{p}");
+            Logger.LogDebug($"{p}");
         }
     }
 

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -54,11 +54,17 @@ public partial class Context : IDisposable
     public IEnumerable<PackageRule> PackageRules { get; protected set; }
     protected readonly Microsoft.Extensions.Logging.ILogger Logger;
 
-    public Context(IConfigurationRoot configuration, IEnumerable<Uri> sources, IConsole console)
+    public Context(
+        IConfigurationRoot configuration,
+        IEnumerable<Uri> sources,
+        IConsole console,
+        Microsoft.Extensions.Logging.ILogger logger
+    )
     {
         Assert.NotNull(configuration);
         Configuration = configuration;
         Console = console;
+        Logger = logger;
         Cache = new();
 
         var entryAssembly = Assembly.GetEntryAssembly();
@@ -154,6 +160,7 @@ public partial class Context : IDisposable
     {
         Configuration = other.Configuration;
         Console = other.Console;
+        Logger = other.Logger;
         Sources = other.Sources;
         Cache = other.Cache;
         Build = other.Build;

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -22,6 +22,7 @@
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -22,7 +22,6 @@
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
-    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -41,9 +41,10 @@ public partial class Context : Core.Context
         Uri target,
         string? repository,
         string? directory,
-        IConsole console
+        IConsole console,
+        ILogger logger
     )
-        : base(configuration, sources, console)
+        : base(configuration, sources, console, logger)
     {
         MinUnityVersion = minUnityVersion;
         Target = target;

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
-using NLog;
+using Microsoft.Extensions.Logging;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Protocol.Core.Types;
@@ -18,8 +18,6 @@ public partial class Context : Core.Context
 {
     protected const string kUnitySection = @"unity";
     protected const string kDefaultFramework = @"netstandard2.0";
-
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     public string MinUnityVersion { get; protected set; }
     public Uri Target { get; protected set; }

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -66,7 +67,7 @@ public partial class Context
         {
             var readme = packageJson.GenerateReadme(originalReadme: packageReader.GetReadme());
             files.Add(@"README.md", readme);
-            Logger.Debug($"--- README\n{Encoding.Default.GetString(files[@"README.md"])}\n---");
+            Logger.LogDebug($"--- README\n{Encoding.Default.GetString(files[@"README.md"])}\n---");
         }
 
         // create & add LICENSE
@@ -78,7 +79,7 @@ public partial class Context
                 copyrightHolder: packageReader.NuspecReader.GetOwners()
             );
             files.Add(@"LICENSE.md", license);
-            Logger.Debug($"--- LICENSE\n{Encoding.Default.GetString(files[@"LICENSE.md"])}\n---");
+            Logger.LogDebug($"--- LICENSE\n{Encoding.Default.GetString(files[@"LICENSE.md"])}\n---");
         }
 
         // create & add CHANGELOG
@@ -86,7 +87,7 @@ public partial class Context
         {
             var changelog = packageJson.GenerateChangelog(packageReader.NuspecReader.GetReleaseNotes());
             files.Add(@"CHANGELOG.md", changelog);
-            Logger.Debug($"--- CHANGELOG\n{Encoding.Default.GetString(files[@"CHANGELOG.md"])}\n---");
+            Logger.LogDebug($"--- CHANGELOG\n{Encoding.Default.GetString(files[@"CHANGELOG.md"])}\n---");
         }
 
         // add file references to package.json
@@ -96,7 +97,7 @@ public partial class Context
         Assert.False(files.ContainsKey(@"package.json"));
         var packageJsonString = packageJson.ToJson();
         files.Add(@"package.json", packageJsonString);
-        Logger.Debug($"--- PACKAGE.JSON\n{packageJsonString}\n---");
+        Logger.LogDebug($"--- PACKAGE.JSON\n{packageJsonString}\n---");
 
         // add meta files
         files.AddMetaFiles(packageJson.Name);

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -95,14 +96,14 @@ public partial class Context
                 var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
 
                 if (!string.IsNullOrEmpty(stdout))
-                    Logger.Info($"NPM: {stdout}");
+                    Logger.LogInformation($"NPM: {stdout}");
 
                 if (!string.IsNullOrEmpty(stderr))
-                    Logger.Error($"NPM: {stderr}");
+                    Logger.LogError($"NPM: {stderr}");
             }
             catch (Exception e)
             {
-                Logger.Error($"NPM: {e.Message}");
+                Logger.LogError($"NPM: {e.Message}");
             }
 
             System.IO.Directory.Delete(tempDir, recursive: true);

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using HandlebarsDotNet;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using NuGet.Protocol.Core.Types;
 using Xunit;
 
@@ -72,7 +73,7 @@ public partial class Context
 
     protected virtual string PatchPackageId(string packageId)
     {
-        Logger.Debug($"before: {packageId}");
+        Logger.LogTrace($"before: {packageId}");
         var metadata = CachedMetadata[packageId.ToLowerInvariant()];
         Assert.NotNull(metadata);
 
@@ -83,7 +84,7 @@ public partial class Context
 
         var template = Handlebars.Compile(namingTemplate);
         var result = Regex.Replace(template(metadata).ToLowerInvariant().Replace(@" ", ""), @"\W", @".");
-        Logger.Debug($"after: {result}");
+        Logger.LogTrace($"after: {result}");
         return result;
     }
 

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -90,14 +90,14 @@ public partial class Context
 
     protected virtual string PatchPackageVersion(string packageId, string packageVersion)
     {
-        Logger.Debug($"before: {packageId}: {packageVersion}");
+        Logger.LogTrace($"before: {packageId}: {packageVersion}");
         var packageRule = GetPackageRule(packageId);
         var versionRegex = !string.IsNullOrEmpty(packageRule.Version)
             ? packageRule.Version
             : Context.DefaultPackageRule.Version;
 
         var result = Regex.Match(packageVersion, versionRegex).Value;
-        Logger.Debug($"after: {packageId}: {result}");
+        Logger.LogTrace($"after: {packageId}: {result}");
 
         return result;
     }

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
-    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -43,7 +44,12 @@ public partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
+        using var context = new Core.Context(
+            configuration: Configuration!,
+            sources: sources,
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Context>()
+        );
         using var packageStream = await context.FetchPackage(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -43,7 +44,12 @@ public partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
+        using var context = new Core.Context(
+            configuration: Configuration!,
+            sources: sources,
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Core.Context>()
+        );
         var package = await context.GetPackageInformation(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier/CoreActions/List.cs
+++ b/NuGettier/CoreActions/List.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -43,7 +44,12 @@ public partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
+        using var context = new Core.Context(
+            configuration: Configuration!,
+            sources: sources,
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Core.Context>()
+        );
         var results = await context.GetPackageVersions(
             packageId: packageId,
             preRelease: preRelease,

--- a/NuGettier/CoreActions/ListDependencies.cs
+++ b/NuGettier/CoreActions/ListDependencies.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -44,7 +45,12 @@ public partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
+        using var context = new Core.Context(
+            configuration: Configuration!,
+            sources: sources,
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Context>()
+        );
         var packages = await context.GetPackageDependencies(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier/CoreActions/Search.cs
+++ b/NuGettier/CoreActions/Search.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -41,7 +42,12 @@ public partial class Program
     )
     {
         Assert.NotNull(Configuration);
-        using var context = new Core.Context(configuration: Configuration!, sources: sources, console: console);
+        using var context = new Core.Context(
+            configuration: Configuration!,
+            sources: sources,
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Core.Context>()
+        );
         var results = await context.SearchPackages(searchTerm: searchTerm, cancellationToken: cancellationToken);
 
         if (results is null)

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="NuGet.Resolver" Version="6.8.0"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0"/>
     <PackageReference Include="Xunit" Version="2.6.4"/>
   </ItemGroup>
 

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="DotNetConfig" Version="1.0.6"/>
     <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="DotNetConfig" Version="1.0.6"/>
     <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="DotNetConfig" Version="1.0.6"/>
     <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -34,6 +34,7 @@
   <ItemGroup Label="package dependencies">
     <PackageReference Include="DotNetConfig" Version="1.0.6"/>
     <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
+    <PackageReference Include="Karambolo.Extensions.Logging.File" Version="3.5.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -45,7 +45,7 @@ public partial class Program
 
     static async Task<int> Main(string[] args)
     {
-        Logger.Debug($"called with args: {string.Join(" ", args.Select(a => $"'{a}'"))}");
+        Logger.LogDebug($"called with args: {string.Join(" ", args.Select(a => $"'{a}'"))}");
         Assert.NotNull(Configuration);
 
         var cmd = new RootCommand("Extended NuGet helper utility")

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -35,9 +35,15 @@ public partial class Program
             .AddConsole() //< add console as logging target
             .AddDebug() //< add debug output as logging target
             .AddFile() //< add file output as logging target
+#if DEBUG
             .SetMinimumLevel(
-                LogLevel.Debug
-            ) //< set minimum level to log
+                LogLevel.Trace
+            ) //< set minimum level to trace in Debug
+#else
+            .SetMinimumLevel(
+                LogLevel.Error
+            ) //< set minimum level to error in Release
+#endif
         ;
     });
 

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -9,7 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotNetConfig;
 using Microsoft.Extensions.Configuration;
-using NLog;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Debug;
 using Xunit;
 
 #nullable enable
@@ -28,17 +29,22 @@ public partial class Program
         }
     }
 
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+    public static readonly ILoggerFactory MainLoggerFactory = LoggerFactory.Create(builder =>
+    {
+        builder
+            .AddConsole() //< add console as logging target
+            .AddDebug() //< add debug output as logging target
+            .AddFile() //< add file output as logging target
+            .SetMinimumLevel(
+                LogLevel.Debug
+            ) //< set minimum level to log
+        ;
+    });
+
+    private static readonly ILogger Logger = MainLoggerFactory.CreateLogger<Program>();
 
     static async Task<int> Main(string[] args)
     {
-        LogManager
-            .Setup()
-            .LoadConfiguration(builder =>
-            {
-                builder.ForLogger().FilterMinLevel(LogLevel.Info).WriteToConsole();
-                builder.ForLogger().FilterMinLevel(LogLevel.Debug).WriteToFile(fileName: "nugettier.log");
-            });
         Logger.Debug($"called with args: {string.Join(" ", args.Select(a => $"'{a}'"))}");
         Assert.NotNull(Configuration);
 

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -63,7 +64,8 @@ public partial class Program
             target: target,
             repository: repository,
             directory: directory,
-            console: console
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Upm.Context>()
         );
 
         var packageJson = await context.GetPackageJson(

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -83,7 +83,7 @@ public partial class Program
         using (package)
         {
             // write output package.tar.gz
-            Logger.Info($"writing package {packageIdentifier}.tgz");
+            Logger.LogInformation($"writing package {packageIdentifier}.tgz");
             await package.WriteToTarGzAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}.tgz"));
         }
 

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -64,7 +65,8 @@ public partial class Program
             target: target,
             repository: repository,
             directory: directory,
-            console: console
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Upm.Context>()
         );
         var tuple = await context.PackUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -7,6 +7,7 @@ using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace NuGettier;
@@ -57,7 +58,8 @@ public partial class Program
             target: target,
             repository: repository,
             directory: directory,
-            console: console
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Upm.Context>()
         );
         var result = await context.PublishUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -75,7 +75,7 @@ public partial class Program
 
         if (result != 0)
         {
-            Logger.Error($"publishing failed");
+            Logger.LogError($"publishing failed");
         }
 
         return result;

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -83,7 +83,7 @@ public partial class Program
         using (package)
         {
             // write output package.tar.gz
-            Logger.Info($"writing unpacked package {packageIdentifier}");
+            Logger.LogInformation($"writing unpacked package {packageIdentifier}");
             await package.WriteToDirectoryAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}"));
         }
         return 0;

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -64,7 +65,8 @@ public partial class Program
             target: target,
             repository: repository,
             directory: directory,
-            console: console
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Upm.Context>()
         );
         var tuple = await context.PackUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -63,7 +64,8 @@ public partial class Program
             target: target,
             repository: repository,
             directory: directory,
-            console: console
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Amalgamate.Context>()
         );
 
         var packageJson = await context.GetPackageJson(

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -63,7 +64,8 @@ public partial class Program
             target: target,
             repository: repository,
             directory: directory,
-            console: console
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Amalgamate.Context>()
         );
         var tuple = await context.PackUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -82,7 +82,7 @@ public partial class Program
         using (package)
         {
             // write output package.tar.gz
-            Logger.Info($"writing package {packageIdentifier}.tgz");
+            Logger.LogInformation($"writing package {packageIdentifier}.tgz");
             await package.WriteToTarGzAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}.tgz"));
         }
 

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -7,6 +7,7 @@ using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace NuGettier;
@@ -57,7 +58,8 @@ public partial class Program
             target: target,
             repository: repository,
             directory: directory,
-            console: console
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Amalgamate.Context>()
         );
         var result = await context.PublishUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -75,7 +75,7 @@ public partial class Program
 
         if (result != 0)
         {
-            Logger.Error($"publishing failed");
+            Logger.LogError($"publishing failed");
         }
 
         return result;

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -82,7 +82,7 @@ public partial class Program
         using (package)
         {
             // write output package.tar.gz
-            Logger.Info($"writing unpacked package {packageIdentifier}");
+            Logger.LogInformation($"writing unpacked package {packageIdentifier}");
             await package.WriteToDirectoryAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}"));
         }
         return 0;

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -63,7 +64,8 @@ public partial class Program
             target: target,
             repository: repository,
             directory: directory,
-            console: console
+            console: console,
+            logger: MainLoggerFactory.CreateLogger<Amalgamate.Context>()
         );
         var tuple = await context.PackUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0"/>
-    <PackageReference Include="NLog" Version="5.2.7"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.8.0"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.0"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.0"/>


### PR DESCRIPTION
- build (NuGettier): remove dependency on NLog
- build (NuGettier.Core): remove dependency on NLog
- build (NuGettier.Upm): remove dependency on NLog
- build (NuGettier.Amalgamate): remove dependency on NLog
- build (Prototype): remove dependency on NLog
- build (NuGettier): add dependency on Microsoft.Extensions.Logging (v8.0.0)
- build (NuGettier): add dependency on Microsoft.Extensions.Logging.Console (v8.0.0)
- build (NuGettier): add dependency on Microsoft.Extensions.Logging.Debug (v8.0.0)
- build (NuGettier): add dependency on Microsoft.Extensions.FileProviders.Physical (v8.0.0)
- build (NuGettier): add dependency on Microsoft.Extensions.Logging.Configuration (v8.0.0)
- build (NuGettier): add dependency on package Microsoft.Extensions.Options.ConfigurationExtensions (v8.0.0)
- build (NuGettier): add dependency on package System.Threading.Channels (v8.0.0)
- build (NuGettier): add dependency on package Karambolo.Extensions.Logging.File (v3.5.0)
- build (NuGettier.Core): add dependency on Microsoft.Extensions.Logging (v8.0.0)
- build (NuGettier.Core): add dependency on Microsoft.Extensions.Logging.Console (v8.0.0)
- build (NuGettier.Core): add dependency on Microsoft.Extensions.Logging.Debug (v8.0.0)
- build (NuGettier.Upm): add dependency on Microsoft.Extensions.Logging (v8.0.0)
- build (NuGettier.Upm): add dependency on Microsoft.Extensions.Logging.Console (v8.0.0)
- build (NuGettier.Upm): add dependency on Microsoft.Extensions.Logging.Debug (v8.0.0)
- build (NuGettier.Amalgamate): add dependency on Microsoft.Extensions.Logging (v8.0.0)
- build (NuGettier.Amalgamate): add dependency on Microsoft.Extensions.Logging.Console (v8.0.0)
- build (NuGettier.Amalgamate): add dependency on Microsoft.Extensions.Logging.Debug (v8.0.0)
- build (Prototype): add dependency on Microsoft.Extensions.Logging (v8.0.0)
- build (Prototype): add dependency on Microsoft.Extensions.Logging.Console (v8.0.0)
- build (Prototype): add dependency on Microsoft.Extensions.Logging.Debug (v8.0.0)
- refactor (NuGettier): adapt to use Microsoft.Extensions.Logging.Logger for all logging tasks
- refactor (NuGettier.Core): replace NLog.Logger with Microsoft.Extensions.Logging.ILogger as Core.Context property
- refactor (NuGettier.Core): pass instance of Microsoft.Extensions.Logging.ILogger to Core.Context.ctor() to set internal property
- refactor (NuGettier.Upm): remove static NLog.Logger from Upm.Context
- refactor (NuGettier.Upm): remove static NLog.Logger from Amalgamate.Context
- refactor (NuGettier.Upm): adapt to passing instance of Microsoft.Extensions.Logging.ILogger to Upm.Context.ctor()
- refactor (NuGettier.Upm): adapt to passing instance of Microsoft.Extensions.Logging.ILogger to Amalgamate.Context.ctor()
- refactor (NuGettier): create new logger instance to pass to Core.Context.ctor() in Get command
- refactor (NuGettier): create new logger instance to pass to Core.Context.ctor() in Info command
- refactor (NuGettier): create new logger instance to pass to Core.Context.ctor() in List command
- refactor (NuGettier): create new logger instance to pass to Core.Context.ctor() in ListDependencies command
- refactor (NuGettier): create new logger instance to pass to Core.Context.ctor() in Search command
- refactor (NuGettier): create new logger instance to pass to Upm.Context.ctor() in UpmInfo command
- refactor (NuGettier): create new logger instance to pass to Upm.Context.ctor() in UpmPack command
- refactor (NuGettier): create new logger instance to pass to Upm.Context.ctor() in UpmPublish command
- refactor (NuGettier): create new logger instance to pass to Upm.Context.ctor() in UpmUnpack command
- refactor (NuGettier): create new logger instance to pass to Amalgamate.Context.ctor() in AmalgamateInfo command
- refactor (NuGettier): create new logger instance to pass to Amalgamate.Context.ctor() in AmalgamatePack command
- refactor (NuGettier): create new logger instance to pass to Amalgamate.Context.ctor() in AmalgamatePublish command
- refactor (NuGettier): create new logger instance to pass to Amalgamate.Context.ctor() in AmalgamateUnpack command
- refactor (NuGettier): adapt logging to ILogger in UpmPack command
- refactor (NuGettier): adapt logging to ILogger in UpmPublish command
- refactor (NuGettier): adapt logging to ILogger in UpmUnpack command
- refactor (NuGettier): adapt logging to ILogger in AmalgamatePack command
- refactor (NuGettier): adapt logging to ILogger in AmalgamatePublish command
- refactor (NuGettier): adapt logging to ILogger in AmalgamateUnpack command
- refactor (NuGettier): adapt logging to ILogger in Program.Main()
- refactor (NuGettier.Core): adapt logging to ILogger in Core.Context.ctor()
- refactor (NuGettier.Core): adapt logging to ILogger in Upm.Context.PackUpmPackage()
- refactor (NuGettier.Core): adapt logging to ILogger in Upm.Context.NuGettier.PublishUpmPackage()
- refactor (NuGettier.Core): adapt logging to ILogger in Upm.Context.PatchPackageId()
- refactor (NuGettier.Core): adapt logging to ILogger in Upm.Context.PatchPackageVersion()
- refactor (NuGettier): change log-level to 'trace' in Debug, 'error' in Release
