### PR TITLE
refactor (NuGettier.Upm): retrieve package rule by string equality and/or regex matching

### DIFF
--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -31,6 +31,7 @@ public partial class Context
                 packageRulesByLengthDescending.Where(r => Regex.IsMatch(r.Id, packageId)).FirstOrDefault(defaultRule)
             );
 
+        // create and return new package rule if retrieved one does not contain important information
         if (
             string.IsNullOrEmpty(packageRule.Name)
             || string.IsNullOrEmpty(packageRule.Version)

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -19,7 +19,17 @@ public partial class Context
     public PackageRule GetPackageRule(string packageId)
     {
         var defaultRule = PackageRules.Where(r => string.IsNullOrEmpty(r.Id)).FirstOrDefault(DefaultPackageRule);
-        var packageRule = PackageRules.Where(r => r.Id == packageId).FirstOrDefault(defaultRule);
+
+        // descending order used for regex match, so that `.*` will match last
+        // rationale: this allows to have generic rules for e.g. "Microsoft.Extensions.Logging.*" and "Microsoft.Extensions.*" that don't overlap
+        var packageRulesByLengthDescending = PackageRules.OrderByDescending(r => r.Id.Length);
+
+        // search for equality first, then regex to have e.g. a specific rule for "System.Text.Json" and a generic rule for "System.Text.*" that don't overlap
+        var packageRule = packageRulesByLengthDescending
+            .Where(r => r.Id == packageId)
+            .FirstOrDefault(
+                packageRulesByLengthDescending.Where(r => Regex.IsMatch(r.Id, packageId)).FirstOrDefault(defaultRule)
+            );
 
         if (
             string.IsNullOrEmpty(packageRule.Name)


### PR DESCRIPTION
- refactor (NuGettier.Upm): retrieve package rule by string equality and/or regex matching
- doc (NuGettier.Upm): explain rationale behind adhoc package rule creation
