### PR TITLE
refactor (NuGettier.Core et al.): add Microsoft.Extensions.Logging.ILoggerFactory instance to Core.Context and adapt ctors accordingly

### DIFF
--- a/NuGettier.Amalgamate/Context/Context.cs
+++ b/NuGettier.Amalgamate/Context/Context.cs
@@ -19,6 +19,29 @@ public partial class Context : Upm.Context
         string? repository,
         string? directory,
         IConsole console,
+        ILoggerFactory loggerFactory
+    )
+        : this(
+            configuration: configuration,
+            sources: sources,
+            minUnityVersion: minUnityVersion,
+            target: target,
+            repository: repository,
+            directory: directory,
+            console: console,
+            loggerFactory: loggerFactory,
+            logger: loggerFactory.CreateLogger<Amalgamate.Context>()
+        ) { }
+
+    protected Context(
+        IConfigurationRoot configuration,
+        IEnumerable<Uri> sources,
+        string minUnityVersion,
+        Uri target,
+        string? repository,
+        string? directory,
+        IConsole console,
+        ILoggerFactory loggerFactory,
         ILogger logger
     )
         : base(
@@ -29,6 +52,7 @@ public partial class Context : Upm.Context
             repository: repository,
             directory: directory,
             console: console,
+            loggerFactory: loggerFactory,
             logger: logger
         ) { }
 

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -166,6 +166,7 @@ public partial class Context : IDisposable
         Build = other.Build;
         Repositories = other.Repositories;
         PackageRules = other.PackageRules;
+        Logger = other.Logger;
     }
 
     public void Dispose() { }

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -52,6 +52,7 @@ public partial class Context : IDisposable
     public IConsole Console { get; protected set; }
     public BuildInfo Build { get; protected set; }
     public IEnumerable<PackageRule> PackageRules { get; protected set; }
+    protected readonly Microsoft.Extensions.Logging.ILoggerFactory LoggerFactory;
     protected readonly Microsoft.Extensions.Logging.ILogger Logger;
 
     public Context(
@@ -166,6 +167,7 @@ public partial class Context : IDisposable
         Build = other.Build;
         Repositories = other.Repositories;
         PackageRules = other.PackageRules;
+        LoggerFactory = other.LoggerFactory;
         Logger = other.Logger;
     }
 

--- a/NuGettier.Core/Context/Context.cs
+++ b/NuGettier.Core/Context/Context.cs
@@ -59,12 +59,28 @@ public partial class Context : IDisposable
         IConfigurationRoot configuration,
         IEnumerable<Uri> sources,
         IConsole console,
+        Microsoft.Extensions.Logging.ILoggerFactory loggerFactory
+    )
+        : this(
+            configuration: configuration,
+            sources: sources,
+            console: console,
+            loggerFactory: loggerFactory,
+            logger: loggerFactory.CreateLogger<Context>()
+        ) { }
+
+    protected Context(
+        IConfigurationRoot configuration,
+        IEnumerable<Uri> sources,
+        IConsole console,
+        Microsoft.Extensions.Logging.ILoggerFactory loggerFactory,
         Microsoft.Extensions.Logging.ILogger logger
     )
     {
         Assert.NotNull(configuration);
         Configuration = configuration;
         Console = console;
+        LoggerFactory = loggerFactory;
         Logger = logger;
         Cache = new();
 

--- a/NuGettier.Upm/Context/Context.cs
+++ b/NuGettier.Upm/Context/Context.cs
@@ -42,9 +42,32 @@ public partial class Context : Core.Context
         string? repository,
         string? directory,
         IConsole console,
+        ILoggerFactory loggerFactory
+    )
+        : this(
+            configuration: configuration,
+            sources: sources,
+            minUnityVersion: minUnityVersion,
+            target: target,
+            repository: repository,
+            directory: directory,
+            console: console,
+            loggerFactory: loggerFactory,
+            logger: loggerFactory.CreateLogger<Upm.Context>()
+        ) { }
+
+    protected Context(
+        IConfigurationRoot configuration,
+        IEnumerable<Uri> sources,
+        string minUnityVersion,
+        Uri target,
+        string? repository,
+        string? directory,
+        IConsole console,
+        ILoggerFactory loggerFactory,
         ILogger logger
     )
-        : base(configuration, sources, console, logger)
+        : base(configuration, sources, console, loggerFactory, logger)
     {
         MinUnityVersion = minUnityVersion;
         Target = target;

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -48,7 +48,7 @@ public partial class Program
             configuration: Configuration!,
             sources: sources,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Context>()
+            loggerFactory: MainLoggerFactory
         );
         using var packageStream = await context.FetchPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -48,7 +48,7 @@ public partial class Program
             configuration: Configuration!,
             sources: sources,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Core.Context>()
+            loggerFactory: MainLoggerFactory
         );
         var package = await context.GetPackageInformation(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/CoreActions/List.cs
+++ b/NuGettier/CoreActions/List.cs
@@ -48,7 +48,7 @@ public partial class Program
             configuration: Configuration!,
             sources: sources,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Core.Context>()
+            loggerFactory: MainLoggerFactory
         );
         var results = await context.GetPackageVersions(
             packageId: packageId,

--- a/NuGettier/CoreActions/ListDependencies.cs
+++ b/NuGettier/CoreActions/ListDependencies.cs
@@ -49,7 +49,7 @@ public partial class Program
             configuration: Configuration!,
             sources: sources,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Context>()
+            loggerFactory: MainLoggerFactory
         );
         var packages = await context.GetPackageDependencies(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/CoreActions/Search.cs
+++ b/NuGettier/CoreActions/Search.cs
@@ -46,7 +46,7 @@ public partial class Program
             configuration: Configuration!,
             sources: sources,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Core.Context>()
+            loggerFactory: MainLoggerFactory
         );
         var results = await context.SearchPackages(searchTerm: searchTerm, cancellationToken: cancellationToken);
 

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -65,7 +65,7 @@ public partial class Program
             repository: repository,
             directory: directory,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Upm.Context>()
+            loggerFactory: MainLoggerFactory
         );
 
         var packageJson = await context.GetPackageJson(

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -66,7 +66,7 @@ public partial class Program
             repository: repository,
             directory: directory,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Upm.Context>()
+            loggerFactory: MainLoggerFactory
         );
         var tuple = await context.PackUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -59,7 +59,7 @@ public partial class Program
             repository: repository,
             directory: directory,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Upm.Context>()
+            loggerFactory: MainLoggerFactory
         );
         var result = await context.PublishUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -66,7 +66,7 @@ public partial class Program
             repository: repository,
             directory: directory,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Upm.Context>()
+            loggerFactory: MainLoggerFactory
         );
         var tuple = await context.PackUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -65,7 +65,7 @@ public partial class Program
             repository: repository,
             directory: directory,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Amalgamate.Context>()
+            loggerFactory: MainLoggerFactory
         );
 
         var packageJson = await context.GetPackageJson(

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -65,7 +65,7 @@ public partial class Program
             repository: repository,
             directory: directory,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Amalgamate.Context>()
+            loggerFactory: MainLoggerFactory
         );
         var tuple = await context.PackUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -59,7 +59,7 @@ public partial class Program
             repository: repository,
             directory: directory,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Amalgamate.Context>()
+            loggerFactory: MainLoggerFactory
         );
         var result = await context.PublishUpmPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -65,7 +65,7 @@ public partial class Program
             repository: repository,
             directory: directory,
             console: console,
-            logger: MainLoggerFactory.CreateLogger<Amalgamate.Context>()
+            loggerFactory: MainLoggerFactory
         );
         var tuple = await context.PackUpmPackage(
             packageIdVersion: packageIdVersion,


### PR DESCRIPTION
- fix (NuGettier.Core): fix Core.Context.Logger not being copied by cctor
- feature (NuGettier.Core): add Microsoft.Extensions.Logging.ILoggerFactory instance to Core.Context
- refactor (NuGettier.Core): split Core.Context.ctor into public ctor taking ILoggerFactory and protected ctor taking ILogger
- refactor (NuGettier.Upm): split Upm.Context.ctor into public ctor taking ILoggerFactory and protected ctor taking ILogger
- refactor (NuGettier.Amalgamate): split Amalgamate.Context.ctor into public ctor taking ILoggerFactory and protected ctor taking ILogger
