### PR TITLE
refactor (NuGettier): allow overriding default appconfig log-level

### DIFF
--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="DotNetConfig.Configuration" Version="1.0.6"/>
     <PackageReference Include="Karambolo.Extensions.Logging.File" Version="3.5.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -27,6 +27,7 @@ public partial class Program
         {
             configurationRoot ??= new ConfigurationBuilder() //
                 .AddJsonFile("appconfig.json", optional: false, reloadOnChange: false)
+                .AddJsonFile(Path.Join(Environment.CurrentDirectory, "appconfig.json"), optional: true, reloadOnChange: false)
                 .AddDotNetConfig()
                 .Build();
             return configurationRoot;

--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotNetConfig;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Debug;
@@ -28,6 +29,7 @@ public partial class Program
             configurationRoot ??= new ConfigurationBuilder() //
                 .AddJsonFile("appconfig.json", optional: false, reloadOnChange: false)
                 .AddJsonFile(Path.Join(Environment.CurrentDirectory, "appconfig.json"), optional: true, reloadOnChange: false)
+                .AddEnvironmentVariables()
                 .AddDotNetConfig()
                 .Build();
             return configurationRoot;


### PR DESCRIPTION
- refactor (NuGettier): allow CWD/appconfig.json to override system-level one
- build (NuGettier): add dependency on Microsoft.Extensions.Configuration.EnvironmentVariables v8.0.0
- refactor (NuGettier): allow environment variables to override appconfig.json
