### PR TITLE
refactor (NuGettier et al): extend debug logs

### DIFF
--- a/NuGettier.Amalgamate/Context/GetPackageFiles.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageFiles.cs
@@ -38,6 +38,11 @@ public partial class Context
         Assert.NotNull(packageRule);
         if (packageRule.IsRecursive)
         {
+            Logger.LogDebug(
+                "recursing dependencies for {0}@{1}",
+                packageReader.NuspecReader.GetIdentity().Id,
+                packageReader.NuspecReader.GetIdentity().Version
+            );
             var packageDependencyGroup = NuGetFrameworkUtility.GetNearest<PackageDependencyGroup>(
                 packageReader.NuspecReader.GetDependencyGroups(),
                 NugetFramework

--- a/NuGettier.Amalgamate/Context/GetPackageFiles.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageFiles.cs
@@ -43,7 +43,11 @@ public partial class Context
                 NugetFramework
             );
 
-            if (packageDependencyGroup is not null)
+            if (packageDependencyGroup is null)
+            {
+                Logger.TraceLocation().LogError("returned PackageDependencyGroup is null");
+            }
+            else
             {
                 foreach (var dependency in packageDependencyGroup.Packages)
                 {
@@ -61,7 +65,10 @@ public partial class Context
                         cancellationToken: cancellationToken
                     );
                     if (dependencyPackageStream == null)
+                    {
+                        Logger.TraceLocation().LogError("fetched PackageStream is null");
                         continue;
+                    }
 
                     using PackageArchiveReader dependencyPackageReader = new(dependencyPackageStream);
                     var packageFiles = await GetPackageFiles(

--- a/NuGettier.Amalgamate/Context/GetPackageFiles.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageFiles.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -29,6 +30,8 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         FileDictionary files = await base.GetPackageFiles(packageReader, nugetFramework, cancellationToken);
 
         var packageRule = GetPackageRule(packageReader.NuspecReader.GetIdentity().Id);

--- a/NuGettier.Amalgamate/Context/GetPackageJson.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageJson.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -28,6 +29,8 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         return await base.GetPackageJson(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier.Amalgamate/Context/PackUpmPackage.cs
+++ b/NuGettier.Amalgamate/Context/PackUpmPackage.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using NuGet.Common;
@@ -34,6 +35,8 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         return await base.PackUpmPackage(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier.Amalgamate/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Amalgamate/Context/PackageMetadataUtility.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using HandlebarsDotNet;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -23,6 +24,8 @@ public partial class Context
         NuGetFramework nugetFramework
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         var packageDependencyGroup = NuGetFrameworkUtility.GetNearest<PackageDependencyGroup>(
             packageSearchMetadata.DependencySets,
             nugetFramework

--- a/NuGettier.Amalgamate/Context/Utility.cs
+++ b/NuGettier.Amalgamate/Context/Utility.cs
@@ -41,6 +41,7 @@ public partial class Context
 
     protected override IDictionary<string, string> PatchPackageDependencies(IDictionary<string, string> dependencies)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return dependencies
             .Where(d => GetPackageRule(d.Key).IsIgnored == false) //< filter: remove 'ignored' dependencies
             .Where(d => GetPackageRule(d.Key).IsExcluded == true) //< filter: 'excluded' dependencies are not amalgamated

--- a/NuGettier.Amalgamate/Context/Utility.cs
+++ b/NuGettier.Amalgamate/Context/Utility.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using HandlebarsDotNet;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using NuGet.Protocol.Core.Types;
 using NuGettier.Upm;
 using Xunit;
@@ -16,6 +17,7 @@ public partial class Context
 {
     public override Upm.PackageJson PatchPackageJson(Upm.PackageJson packageJson)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         var includedDependencies = packageJson
             .Dependencies.Where(d => GetPackageRule(d.Key).IsIgnored == false) //< filter: remove 'ignored' dependencies
             .Where(d => GetPackageRule(d.Key).IsExcluded == false) //< filter: not 'excluded' dependencies are included)

--- a/NuGettier.Amalgamate/Context/Utility.cs
+++ b/NuGettier.Amalgamate/Context/Utility.cs
@@ -35,6 +35,7 @@ public partial class Context
 
     protected override string PatchPackageId(string packageId)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return $"{base.PatchPackageId(packageId)}.amalgamate";
     }
 

--- a/NuGettier.Core/Context/FetchPackage.cs
+++ b/NuGettier.Core/Context/FetchPackage.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -26,6 +27,7 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         using var nugetLogger = NuGetLogger.Create(LoggerFactory);
 
         packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);

--- a/NuGettier.Core/Context/FetchPackage.cs
+++ b/NuGettier.Core/Context/FetchPackage.cs
@@ -26,12 +26,14 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var nugetLogger = NuGetLogger.Create(LoggerFactory);
+
         packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         IEnumerable<FindPackageByIdResource> resources = await Repositories.GetResourceAsync<FindPackageByIdResource>(
             cancellationToken
         );
         IEnumerable<NuGetVersion> versions = (
-            await resources.GetAllVersionsAsync(packageId, Cache, NullLogger.Instance, cancellationToken)
+            await resources.GetAllVersionsAsync(packageId, Cache, nugetLogger, cancellationToken)
         ).Distinct();
 
         NuGetVersion? packageVersion = default;
@@ -56,7 +58,7 @@ public partial class Context
                         packageId,
                         packageVersion!,
                         Cache,
-                        NullLogger.Instance,
+                        nugetLogger,
                         cancellationToken
                     )
                 )
@@ -67,7 +69,7 @@ public partial class Context
                         packageVersion!,
                         packageStream,
                         Cache,
-                        NullLogger.Instance,
+                        nugetLogger,
                         cancellationToken
                     );
 

--- a/NuGettier.Core/Context/FetchPackage.cs
+++ b/NuGettier.Core/Context/FetchPackage.cs
@@ -41,12 +41,15 @@ public partial class Context
         NuGetVersion? packageVersion = default;
         if (latest)
         {
+            Logger.LogTrace("fetching latest version for {0}", packageId);
             packageVersion = versions.Last();
         }
         else if (version != null)
         {
+            Logger.LogTrace("fetching version {1} for {0}", packageId, version);
             packageVersion = new NuGetVersion(version);
         }
+        Logger.LogDebug("fetching {0}@{1}", packageId, packageVersion);
 
         // no assert here
         // `null` is a valid case when latest==true and no version could not be retrieved (b/c package doesn't exist, e.g.)
@@ -84,6 +87,7 @@ public partial class Context
             }
         }
 
+        Logger.TraceLocation().LogTrace("exit {0} returning null", this.__METHOD__());
         return null;
     }
 }

--- a/NuGettier.Core/Context/FetchPackage.cs
+++ b/NuGettier.Core/Context/FetchPackage.cs
@@ -50,7 +50,11 @@ public partial class Context
 
         // no assert here
         // `null` is a valid case when latest==true and no version could not be retrieved (b/c package doesn't exist, e.g.)
-        if (packageVersion != null)
+        if (packageVersion == null)
+        {
+            Logger.TraceLocation().LogError("package version is null, meaning 'latest' version could not be retrieved");
+        }
+        else
         {
             // return first match
             foreach (var resource in resources)

--- a/NuGettier.Core/Context/FetchPackage.cs
+++ b/NuGettier.Core/Context/FetchPackage.cs
@@ -62,6 +62,7 @@ public partial class Context
             // return first match
             foreach (var resource in resources)
             {
+                Logger.LogDebug("checking if package {0}@{1} exists on {2}", packageId, packageVersion, resource);
                 if (
                     await resource.DoesPackageExistAsync(
                         packageId,

--- a/NuGettier.Core/Context/GetPackageDependencies.cs
+++ b/NuGettier.Core/Context/GetPackageDependencies.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -26,6 +27,7 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         var package = await GetPackageInformation(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier.Core/Context/GetPackageInformation.cs
+++ b/NuGettier.Core/Context/GetPackageInformation.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -26,6 +27,7 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         var packages = await GetPackageVersions(
             packageId: packageId,

--- a/NuGettier.Core/Context/GetPackageVersions.cs
+++ b/NuGettier.Core/Context/GetPackageVersions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -25,6 +26,7 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         IEnumerable<PackageMetadataResource> resources = await Repositories.GetResourceAsync<PackageMetadataResource>(
             cancellationToken
         );

--- a/NuGettier.Core/Context/GetPackageVersions.cs
+++ b/NuGettier.Core/Context/GetPackageVersions.cs
@@ -28,12 +28,13 @@ public partial class Context
         IEnumerable<PackageMetadataResource> resources = await Repositories.GetResourceAsync<PackageMetadataResource>(
             cancellationToken
         );
+        using var nugetLogger = NuGetLogger.Create(LoggerFactory);
         var packages = await resources.GetMetadataAsync(
             packageId,
             includePrerelease: preRelease,
             includeUnlisted: false,
             Cache,
-            NullLogger.Instance,
+            nugetLogger,
             cancellationToken
         );
         return packages.OrderByDescending(p => p.Identity.Version);

--- a/NuGettier.Core/Context/SearchPackages.cs
+++ b/NuGettier.Core/Context/SearchPackages.cs
@@ -28,12 +28,13 @@ public partial class Context
         );
         SearchFilter searchFilter = new(includePrerelease: true);
 
+        using var nugetLogger = NuGetLogger.Create(LoggerFactory);
         return await resources.SearchAsync(
             searchTerm,
             searchFilter,
             skip: 0,
             take: 100,
-            NullLogger.Instance,
+            nugetLogger,
             cancellationToken
         );
     }

--- a/NuGettier.Core/Context/SearchPackages.cs
+++ b/NuGettier.Core/Context/SearchPackages.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -23,6 +24,7 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         IEnumerable<PackageSearchResource> resources = await Repositories.GetResourceAsync<PackageSearchResource>(
             cancellationToken
         );

--- a/NuGettier.Core/Extensions/ILoggerExtension.cs
+++ b/NuGettier.Core/Extensions/ILoggerExtension.cs
@@ -58,4 +58,16 @@ public static class ILoggerExtension
         logger.LogDebug("{0}() {1}:{2}", memberName, sourceFilePath, sourceLineNumber);
         return logger;
     }
+
+    public static ILogger DebugSource(
+        this ILogger logger,
+        object obj,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string sourceFilePath = "",
+        [CallerLineNumber] int sourceLineNumber = 0
+    )
+    {
+        logger.LogDebug("{0}.{1}() {2}:{3}", obj.GetType().FullName, memberName, sourceFilePath, sourceLineNumber);
+        return logger;
+    }
 }

--- a/NuGettier.Core/Extensions/ILoggerExtension.cs
+++ b/NuGettier.Core/Extensions/ILoggerExtension.cs
@@ -47,4 +47,15 @@ public static class ILoggerExtension
         logger.LogDebug("{0}:{1}", sourceFilePath, sourceLineNumber);
         return logger;
     }
+
+    public static ILogger DebugSource(
+        this ILogger logger,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string sourceFilePath = "",
+        [CallerLineNumber] int sourceLineNumber = 0
+    )
+    {
+        logger.LogDebug("{0}() {1}:{2}", memberName, sourceFilePath, sourceLineNumber);
+        return logger;
+    }
 }

--- a/NuGettier.Core/Extensions/NuGetLogger.cs
+++ b/NuGettier.Core/Extensions/NuGetLogger.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGet.Common;
+
+namespace NuGettier.Core;
+
+class NuGetLogger : NuGet.Common.ILogger, IDisposable
+{
+    private readonly Microsoft.Extensions.Logging.ILogger Logger;
+
+    public static NuGetLogger Create(Microsoft.Extensions.Logging.ILogger logger) => new NuGetLogger(logger);
+
+    public static NuGetLogger Create(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) =>
+        new NuGetLogger(loggerFactory);
+
+    private NuGetLogger(Microsoft.Extensions.Logging.ILogger logger)
+    {
+        Logger = logger;
+    }
+
+    private NuGetLogger(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory)
+    {
+        Logger = loggerFactory.CreateLogger<NuGetLogger>();
+    }
+
+    public NuGetLogger(NuGetLogger other)
+    {
+        Logger = other.Logger;
+    }
+
+    #region IDisposable
+    public virtual void Dispose() { }
+    #endregion
+
+    #region NuGet.Common.ILogger
+    public virtual void LogDebug(string data) => Logger.LogDebug(data);
+
+    public virtual void LogVerbose(string data) => Logger.LogInformation(data);
+
+    public virtual void LogInformation(string data) => Logger.LogInformation(data);
+
+    public virtual void LogMinimal(string data) => Logger.LogInformation(data);
+
+    public virtual void LogWarning(string data) => Logger.LogWarning(data);
+
+    public virtual void LogError(string data) => Logger.LogError(data);
+
+    public virtual void LogInformationSummary(string data) => Logger.LogInformation(data);
+
+    public virtual void Log(NuGet.Common.LogLevel level, string data)
+    {
+        switch (level)
+        {
+            case NuGet.Common.LogLevel.Debug:
+                Logger.LogDebug(data);
+                break;
+            case NuGet.Common.LogLevel.Verbose:
+                Logger.LogInformation(data);
+                break;
+            case NuGet.Common.LogLevel.Information:
+                Logger.LogInformation(data);
+                break;
+            case NuGet.Common.LogLevel.Minimal:
+                Logger.LogInformation(data);
+                break;
+            case NuGet.Common.LogLevel.Warning:
+                Logger.LogWarning(data);
+                break;
+            case NuGet.Common.LogLevel.Error:
+                Logger.LogError(data);
+                break;
+        }
+        ;
+    }
+
+    public virtual async Task LogAsync(NuGet.Common.LogLevel level, string data) => await Task.Run(() => Log(level, data));
+
+    public virtual void Log(ILogMessage message)
+    {
+        Log(message.Level, $"{message.Time} [NuGet {message.Code}]: {message.Message}");
+    }
+
+    public virtual async Task LogAsync(ILogMessage message)
+    {
+        await LogAsync(message.Level, $"{message.Time} [NuGet {message.Code}]: {message.Message}");
+    }
+    #endregion
+}

--- a/NuGettier.Upm/Context/GetPackageFiles.cs
+++ b/NuGettier.Upm/Context/GetPackageFiles.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -28,6 +29,7 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return await Task.Run(() =>
         {
             FileDictionary files = new();

--- a/NuGettier.Upm/Context/GetPackageInformation.cs
+++ b/NuGettier.Upm/Context/GetPackageInformation.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -27,6 +28,7 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         packageIdVersion.SplitPackageIdVersion(out var packageId, out var version, out var latest);
         var packageSearchMetadata = await base.GetPackageInformation(
             packageIdVersion: packageIdVersion,

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -27,6 +28,7 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         var package = await GetPackageInformation(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -34,6 +34,8 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         // build package.json from package information
         var packageJson = await GetPackageJson(
             packageIdVersion: packageIdVersion,

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -117,6 +117,7 @@ public partial class Context
         NuGetFramework nugetFramework
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         var packageDependencyGroup = NuGetFrameworkUtility.GetNearest<PackageDependencyGroup>(
             packageSearchMetadata.DependencySets,
             nugetFramework

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -26,6 +26,7 @@ public partial class Context
 
     protected virtual string GetPackageVersion(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return packageSearchMetadata.Identity.Version.ToString();
     }
 

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -85,6 +85,7 @@ public partial class Context
 
     protected virtual IEnumerable<Person> GetPackageContributors(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         var otherAuthors = packageSearchMetadata.Authors.Split(',', ';', ' ');
         if (otherAuthors.Length <= 1)
             return new List<Person>();

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -68,6 +68,7 @@ public partial class Context
 
     protected virtual Person GetPackageAuthor(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         var firstAuthor = packageSearchMetadata.Authors.Split(',', ';', ' ').First();
         if (string.IsNullOrEmpty(firstAuthor))
         {

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -108,6 +108,7 @@ public partial class Context
         IPackageSearchMetadata packageSearchMetadata
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return new PublishingConfiguration() { Registry = string.Empty, };
     }
 

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -44,6 +44,7 @@ public partial class Context
 
     protected virtual string GetPackageDescription(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return packageSearchMetadata.Description;
     }
 

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -32,6 +32,7 @@ public partial class Context
 
     protected virtual string? GetPackageLicense(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return packageSearchMetadata.LicenseMetadata == null
             ? string.Empty
             : packageSearchMetadata.LicenseMetadata.LicenseExpression != null

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using HandlebarsDotNet;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -19,6 +20,7 @@ public partial class Context
 {
     protected virtual string GetPackageId(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return packageSearchMetadata.Identity.Id;
     }
 

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -50,6 +50,7 @@ public partial class Context
 
     protected virtual string GetPackageDisplayName(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return packageSearchMetadata.Title;
     }
 

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -95,6 +95,7 @@ public partial class Context
 
     protected virtual Repository GetPackageRepository(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return new Repository()
         {
             RepoType = @"git",

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -62,6 +62,7 @@ public partial class Context
 
     protected virtual IEnumerable<string> GetPackageKeywords(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return packageSearchMetadata.Tags.Split(',', ';', ' ').Where(t => !string.IsNullOrEmpty(t));
     }
 

--- a/NuGettier.Upm/Context/PackageMetadataUtility.cs
+++ b/NuGettier.Upm/Context/PackageMetadataUtility.cs
@@ -56,6 +56,7 @@ public partial class Context
 
     protected virtual string? GetPackageHomepage(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         return packageSearchMetadata.ProjectUrl?.ToString();
     }
 

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -38,6 +38,7 @@ public partial class Context
         CancellationToken cancellationToken
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         var tuple = await PackUpmPackage(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -122,6 +122,8 @@ public partial class Context
 
     protected virtual IDictionary<string, string> PatchPackageDependencies(IDictionary<string, string> dependencies)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         return dependencies
             .Where(d => GetPackageRule(d.Key).IsIgnored == false) //< filter: remove 'ignored' dependencies
             .ToDictionary(d => PatchPackageId(d.Key), d => PatchPackageVersion(d.Key, d.Value));

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -87,6 +87,8 @@ public partial class Context
 
     protected virtual string PatchPackageId(string packageId)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         Logger.LogTrace($"before: {packageId}");
         var metadata = CachedMetadata[packageId.ToLowerInvariant()];
         Assert.NotNull(metadata);

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -18,6 +18,7 @@ public partial class Context
 {
     public PackageRule GetPackageRule(string packageId)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         var defaultRule = PackageRules.Where(r => string.IsNullOrEmpty(r.Id)).FirstOrDefault(DefaultPackageRule);
 
         // descending order used for regex match, so that `.*` will match last

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -131,6 +131,8 @@ public partial class Context
 
     protected virtual PackageJson ConvertToPackageJson(IPackageSearchMetadata packageSearchMetadata)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         return new PackageJson()
         {
             Name = GetPackageId(packageSearchMetadata),

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -106,6 +106,8 @@ public partial class Context
 
     protected virtual string PatchPackageVersion(string packageId, string packageVersion)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         Logger.LogTrace($"before: {packageId}: {packageVersion}");
         var packageRule = GetPackageRule(packageId);
         var versionRegex = !string.IsNullOrEmpty(packageRule.Version)

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -55,6 +55,8 @@ public partial class Context
 
     public virtual PackageJson PatchPackageJson(PackageJson packageJson)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         // get packageRule for this package
         var packageRule = GetPackageRule(packageJson.Name);
 

--- a/NuGettier.Upm/StringFactories/ChangelogFactory.cs
+++ b/NuGettier.Upm/StringFactories/ChangelogFactory.cs
@@ -21,6 +21,8 @@ public class ChangelogFactory : IChangelogFactory
 
     public virtual string GenerateChangelog(string name, string version, string releaseNotes)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         var template = Handlebars.Compile(
             EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.CHANGELOG.md")
         );

--- a/NuGettier.Upm/StringFactories/LicenseFactory.cs
+++ b/NuGettier.Upm/StringFactories/LicenseFactory.cs
@@ -47,6 +47,8 @@ public class LicenseFactory : ILicenseFactory
         string licenseUrl
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         if (string.IsNullOrEmpty(copyright))
         {
             copyright = $"(C) copyrightHolder, published under {license}.";

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -41,6 +41,8 @@ public class MetaFactory : IMetaFactory
 
     public virtual string GenerateFileMeta(string seed, string filename)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         var guid = new MetaGen.Guid(seed, filename);
         var metaTemplate = Handlebars.Compile(
             Path.GetExtension(filename).EndsWith(".dll")

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -21,6 +21,8 @@ public class MetaFactory : IMetaFactory
 
     public virtual string GenerateFolderMeta(string seed, string dirname)
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         var guid = new MetaGen.Guid(seed, dirname);
         var metaTemplate = Handlebars.Compile(
             EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.folder.meta")

--- a/NuGettier.Upm/StringFactories/ReadmeFactory.cs
+++ b/NuGettier.Upm/StringFactories/ReadmeFactory.cs
@@ -33,6 +33,8 @@ public class ReadmeFactory : IReadmeFactory
         string applicationVersion
     )
     {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
         var template = Handlebars.Compile(
             EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.README.md")
         );

--- a/NuGettier/CoreActions/Get.cs
+++ b/NuGettier/CoreActions/Get.cs
@@ -43,7 +43,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "Get");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(Get));
         Assert.NotNull(Configuration);
         using var context = new Core.Context(
             configuration: Configuration!,
@@ -152,7 +152,7 @@ public partial class Program
             packageStream.WriteTo(fileStream);
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "Get");
+        Logger.LogTrace("exit {0} without error", nameof(Get));
         return 0;
     }
 }

--- a/NuGettier/CoreActions/Info.cs
+++ b/NuGettier/CoreActions/Info.cs
@@ -43,7 +43,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "Info");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(Info));
         Assert.NotNull(Configuration);
         using var context = new Core.Context(
             configuration: Configuration!,
@@ -85,7 +85,7 @@ public partial class Program
                     Console.WriteLine($"{kvp.Key}: {kvp.Value}");
                 }
             }
-            Logger.LogTrace("exit {0} command handler without error (short mode)", "Info");
+            Logger.LogTrace("exit {0} without error (short mode)", nameof(Info));
             return 0;
         }
 
@@ -128,7 +128,7 @@ public partial class Program
             //Task<IEnumerable<VersionInfo>> GetVersionsAsync();
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "Info");
+        Logger.LogTrace("exit {0} without error", nameof(Info));
         return 0;
     }
 }

--- a/NuGettier/CoreActions/List.cs
+++ b/NuGettier/CoreActions/List.cs
@@ -43,7 +43,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "List");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(List));
         Assert.NotNull(Configuration);
         using var context = new Core.Context(
             configuration: Configuration!,
@@ -77,7 +77,7 @@ public partial class Program
                     Console.WriteLine($"{version}");
                 }
             }
-            Logger.LogTrace("exit {0} command handler without error (short mode)", "List");
+            Logger.LogTrace("exit {0} without error (short mode)", nameof(List));
             return 0;
         }
 
@@ -93,7 +93,7 @@ public partial class Program
             }
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "List");
+        Logger.LogTrace("exit {0} without error", nameof(List));
         return 0;
     }
 }

--- a/NuGettier/CoreActions/ListDependencies.cs
+++ b/NuGettier/CoreActions/ListDependencies.cs
@@ -44,7 +44,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "ListDependencies");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(ListDependencies));
         Assert.NotNull(Configuration);
         using var context = new Core.Context(
             configuration: Configuration!,
@@ -79,7 +79,7 @@ public partial class Program
                     Console.WriteLine($"{kvp.Key}@{kvp.Value}");
                 }
             }
-            Logger.LogTrace("exit {0} command handler without error (short mode)", "ListDependencies");
+            Logger.LogTrace("exit {0} without error (short mode)", nameof(ListDependencies));
             return 0;
         }
 
@@ -123,7 +123,7 @@ public partial class Program
             }
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "ListDependencies");
+        Logger.LogTrace("exit {0} without error", nameof(ListDependencies));
         return 0;
     }
 }

--- a/NuGettier/CoreActions/Search.cs
+++ b/NuGettier/CoreActions/Search.cs
@@ -41,7 +41,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "Search");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(Search));
         Assert.NotNull(Configuration);
         using var context = new Core.Context(
             configuration: Configuration!,
@@ -71,7 +71,7 @@ public partial class Program
                     Console.WriteLine($"{kvp.Key}@{kvp.Value}");
                 }
             }
-            Logger.LogTrace("exit {0} command handler without error (short mode)", "Search");
+            Logger.LogTrace("exit {0} without error (short mode)", nameof(Search));
             return 0;
         }
 
@@ -87,7 +87,7 @@ public partial class Program
             }
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "Search");
+        Logger.LogTrace("exit {0} without error", nameof(Search));
         return 0;
     }
 }

--- a/NuGettier/Options.cs
+++ b/NuGettier/Options.cs
@@ -8,11 +8,15 @@ using System.CommandLine.IO;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace NuGettier;
 
 public partial class Program
 {
+    private static Option<LogLevel> OutputLogLevelOption =
+        new(aliases: ["--verbosity", "-v"], description: "log verbosity level");
+
     private static Option<bool> OutputJsonOption =
         new(aliases: ["--json", "-j"], description: "whether to output result as JSON (for piping into `jq` etc)");
 

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -56,7 +56,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "UpmInfo");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(UpmInfo));
         Assert.NotNull(Configuration);
         using var context = new Upm.Context(
             configuration: Configuration!,
@@ -108,7 +108,7 @@ public partial class Program
             }
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "UpmInfo");
+        Logger.LogTrace("exit {0} without error", nameof(UpmInfo));
         return 0;
     }
 }

--- a/NuGettier/UpmActions/UpmPack.cs
+++ b/NuGettier/UpmActions/UpmPack.cs
@@ -57,7 +57,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "UpmPack");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(UpmPack));
         Assert.NotNull(Configuration);
         using var context = new Upm.Context(
             configuration: Configuration!,
@@ -91,7 +91,7 @@ public partial class Program
             await package.WriteToTarGzAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}.tgz"));
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "UpmPack");
+        Logger.LogTrace("exit {0} without error", nameof(UpmPack));
         return 0;
     }
 }

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -50,7 +50,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "UpmPublish");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(UpmPublish));
         Assert.NotNull(Configuration);
         using var context = new Upm.Context(
             configuration: Configuration!,
@@ -79,7 +79,7 @@ public partial class Program
             Logger.LogError($"failed to publish UPM package for {0}", packageIdVersion);
         }
 
-        Logger.LogTrace("exit {0} command handler with error {1}", "UpmPublish", result);
+        Logger.LogTrace("exit {0} command handler with error {1}", nameof(UpmPublish), result);
         return result;
     }
 }

--- a/NuGettier/UpmActions/UpmUnpack.cs
+++ b/NuGettier/UpmActions/UpmUnpack.cs
@@ -57,7 +57,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "UpmUnpack");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(UpmUnpack));
         Assert.NotNull(Configuration);
         using var context = new Upm.Context(
             configuration: Configuration!,
@@ -91,7 +91,7 @@ public partial class Program
             await package.WriteToDirectoryAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}"));
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "UpmUnpack");
+        Logger.LogTrace("exit {0} without error", nameof(UpmUnpack));
         return 0;
     }
 }

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -56,7 +56,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "AmalgamateInfo");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(AmalgamateInfo));
         Assert.NotNull(Configuration);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
@@ -108,7 +108,7 @@ public partial class Program
             }
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "AmalgamateInfo");
+        Logger.LogTrace("exit {0} without error", nameof(AmalgamateInfo));
         return 0;
     }
 }

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePack.cs
@@ -56,7 +56,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "AmalgamatePack");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(AmalgamatePack));
         Assert.NotNull(Configuration);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
@@ -90,7 +90,7 @@ public partial class Program
             await package.WriteToTarGzAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}.tgz"));
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "AmalgamatePack");
+        Logger.LogTrace("exit {0} without error", nameof(AmalgamatePack));
         return 0;
     }
 }

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -50,7 +50,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "AmalgamatePublish");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(AmalgamatePublish));
         Assert.NotNull(Configuration);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
@@ -79,7 +79,7 @@ public partial class Program
             Logger.LogError($"failed to publish amalgamated UPM package for {0}", packageIdVersion);
         }
 
-        Logger.LogTrace("exit {0} command handler with error {1}", "AmalgamatePublish", result);
+        Logger.LogTrace("exit {0} command handler with error {1}", nameof(AmalgamatePublish), result);
         return result;
     }
 }

--- a/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateUnpack.cs
@@ -56,7 +56,7 @@ public partial class Program
         CancellationToken cancellationToken
     )
     {
-        Logger.LogTrace("entered {0} command handler", "AmalgamateUnpack");
+        using var scope = Logger.TraceLocation().BeginScope(nameof(AmalgamateUnpack));
         Assert.NotNull(Configuration);
         using var context = new Amalgamate.Context(
             configuration: Configuration!,
@@ -90,7 +90,7 @@ public partial class Program
             await package.WriteToDirectoryAsync(Path.Join(outputDirectory.FullName, $"{packageIdentifier}"));
         }
 
-        Logger.LogTrace("exit {0} command handler without error", "AmalgamateUnpack");
+        Logger.LogTrace("exit {0} without error", nameof(AmalgamateUnpack));
         return 0;
     }
 }


### PR DESCRIPTION
- feature (NuGettier.Core): add object.__METHOD__() extension method
- feature (NuGettier.Core): add ILogger.TraceLocation() extension method
- feature (NuGettier.Core): add ILogger.DebugLocation() extension method
- feature (NuGettier.Core): add ILogger.TraceSource() extension method
- feature (NuGettier.Core): add ILogger.TraceSource(object) extension method
- feature (NuGettier.Core): add ILogger.DebugSource() extension method
- feature (NuGettier.Core): add ILogger.DebugSource(object) extension method
- feature (NuGettier.Core): implement NuGet.Common.ILogger wrapping to Microsoft.Extensions.Logging.ILogger
- refactor (NuGettier): improve trace logs in Get()
- refactor (NuGettier): improve trace logs in Info()
- refactor (NuGettier): improve trace logs in List()
- refactor (NuGettier): improve trace logs in ListDependencies()
- refactor (NuGettier): improve trace logs in Search()
- refactor (NuGettier): improve trace logs in UpmInfo()
- refactor (NuGettier): improve trace logs in UpmPack()
- refactor (NuGettier): improve trace logs in UpmPublish()
- refactor (NuGettier): improve trace logs in UpmUnpack()
- refactor (NuGettier): improve trace logs in AmalgamateInfo()
- refactor (NuGettier): improve trace logs in AmalgamatePack()
- refactor (NuGettier): improve trace logs in AmalgamatePublish()
- refactor (NuGettier): improve trace logs in AmalgamateUnpack()
- refactor (NuGettier.Core): use NuGetLogger to log NuGet queries in Core.Context.SearchPackages()
- refactor (NuGettier.Core): use NuGetLogger to log NuGet queries in Core.Context.FetchPackage()
- refactor (NuGettier.Core): use NuGetLogger to log NuGet queries in Core.Context.GetPackageVersions()
- refactor (NuGettier.Core): set ILogger scope in Core.Context.FetchPackage()
- refactor (NuGettier.Core): set ILogger scope in Core.Context.GetPackageDependencies()
- refactor (NuGettier.Core): set ILogger scope in Core.Context.GetPackageInformation()
- refactor (NuGettier.Core): set ILogger scope in Core.Context.GetPackageVersions()
- refactor (NuGettier.Core): set ILogger scope in Core.Context.SearchPackages()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageFiles()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageInformation()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageJson()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.PackUpmPackage()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.PublishUpmPackage()
- refactor (NuGettier.Upm): set ILogger scope in ChangelogFactory.GenerateChangelog()
- refactor (NuGettier.Upm): set ILogger scope in LicenseFactory.GenerateLicense()
- refactor (NuGettier.Upm): set ILogger scope in MetaFactory.GenerateFolderMeta()
- refactor (NuGettier.Upm): set ILogger scope in ReadmeFactory.GenerateReadme()
- refactor (NuGettier.Upm): set ILogger scope in MetaFactory.GenerateFileMeta()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageRule()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.PatchPackageJson()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.PatchPackageId()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.PatchPackageVersion()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.PatchPackageDependencies()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.ConvertToPackageJson()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageId()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageVersion()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageLicense()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageDescription()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageDisplayName()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageHomepage()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageKeywords()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageAuthor()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageContributors()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageRepository()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackagePublishingConfiguration()
- refactor (NuGettier.Upm): set ILogger scope in Upm.Context.GetPackageDependencies()
- refactor (NuGettier.Amalgamate): set ILogger scope in Amalgamate.Context.GetPackageFiles()
- refactor (NuGettier.Amalgamate): set ILogger scope in Amalgamate.Context.GetPackageJson()
- refactor (NuGettier.Amalgamate): set ILogger scope in Amalgamate.Context.PackUpmPackage()
- refactor (NuGettier.Amalgamate): set ILogger scope in Amalgamate.Context.PatchPackageId()
- refactor (NuGettier.Amalgamate): set ILogger scope in Amalgamate.Context.PatchPackageId()
- refactor (NuGettier.Amalgamate): set ILogger scope in Amalgamate.Context.PatchPackageDependencies()
- refactor (NuGettier.Amalgamate): set ILogger scope in Amalgamate.Context.GetPackageDependencies()
- refactor (NuGettier.Amalgamate): log errors in Amalgamate.Context.GetPackageFiles()
- refactor (NuGettier.Amalgamate): log recursion in Amalgamate.Context.GetPackageFiles()
- refactor (NuGettier.Core): log errors in Core.Context.FetchPackage()
- refactor (NuGettier.Core): add trace logs to Core.Context.FetchPackage()
- refactor (NuGettier.Core): add debug logs to Core.Context.FetchPackage()
- feature (NuGettier): add option to control verbosity
