### PR TITLE
refactor (NuGettier.Upm): wait for 'npm publish' process with configurable timeout

### DIFF
--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -34,6 +34,7 @@ public partial class Context
         string? token,
         string? npmrc,
         bool dryRun,
+        int timeOut,
         PackageAccessLevel packageAccessLevel,
         CancellationToken cancellationToken
     )

--- a/NuGettier.Upm/Context/PublishUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishUpmPackage.cs
@@ -108,8 +108,12 @@ public partial class Context
                 );
                 process.Start();
 
-                Logger.LogDebug("started process for {0} (waiting until termination to proceed)", process.Id);
-                await process.WaitForExitAsync(cancellationToken);
+                Logger.LogDebug(
+                    "started process for {0} (waiting {1} seconds or until termination to proceed)",
+                    process.Id,
+                    timeOut
+                );
+                process.WaitForExit(timeOut * 1000);
                 Logger.LogDebug("process {0} has terminated with exit code {1}", process.Id, process.ExitCode);
                 exitCode = process.ExitCode;
 

--- a/NuGettier/Constants.cs
+++ b/NuGettier/Constants.cs
@@ -10,4 +10,5 @@ public partial class Program
     const string kUnityKey = "unity";
     const string kPrereleaseSuffixKey = "prerelease-suffix";
     const string kBuildmetaSuffixKey = "buildmeta-suffix";
+    const string kTimeOutKey = "timeout";
 }

--- a/NuGettier/UpmActions/UpmPublish.cs
+++ b/NuGettier/UpmActions/UpmPublish.cs
@@ -29,6 +29,7 @@ public partial class Program
             UpmTokenOption,
             UpmNpmrcOption,
             UpmDryRunOption,
+            UpmTimeOutOption,
             UpmPackageAccessLevel,
         }.WithHandler(CommandHandler.Create(UpmPublish));
 
@@ -45,6 +46,7 @@ public partial class Program
         string? token,
         string? npmrc,
         bool dryRun,
+        int timeOut,
         Upm.PackageAccessLevel access,
         IConsole console,
         CancellationToken cancellationToken
@@ -70,6 +72,7 @@ public partial class Program
             token: token,
             npmrc: npmrc,
             dryRun: dryRun,
+            timeOut: timeOut,
             packageAccessLevel: access,
             cancellationToken: cancellationToken
         );

--- a/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamatePublish.cs
@@ -29,6 +29,7 @@ public partial class Program
             UpmTokenOption,
             UpmNpmrcOption,
             UpmDryRunOption,
+            UpmTimeOutOption,
             UpmPackageAccessLevel,
         }.WithHandler(CommandHandler.Create(AmalgamatePublish));
 
@@ -45,6 +46,7 @@ public partial class Program
         string? token,
         string? npmrc,
         bool dryRun,
+        int timeOut,
         Upm.PackageAccessLevel access,
         IConsole console,
         CancellationToken cancellationToken
@@ -70,6 +72,7 @@ public partial class Program
             token: token,
             npmrc: npmrc,
             dryRun: dryRun,
+            timeOut: timeOut,
             packageAccessLevel: access,
             cancellationToken: cancellationToken
         );

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -65,6 +65,16 @@ public partial class Program
 
     private static Option<bool> UpmDryRunOption = new(aliases: ["--dry-run", "-n"], description: "Dry run");
 
+    private static Option<int> UpmTimeOutOption =
+        new(
+            aliases: ["--timeout", "-w"],
+            description: "Time out (in seconds)",
+            getDefaultValue: () => 60
+        )
+        {
+            IsRequired = false,
+        };
+
     private static Option<Upm.PackageAccessLevel> UpmPackageAccessLevel =
         new(
             aliases: ["--access", "-a",],

--- a/NuGettier/UpmOptions.cs
+++ b/NuGettier/UpmOptions.cs
@@ -69,7 +69,7 @@ public partial class Program
         new(
             aliases: ["--timeout", "-w"],
             description: "Time out (in seconds)",
-            getDefaultValue: () => 60
+            getDefaultValue: () => Configuration.GetSection(kDefaultsSection).GetValue<int>(kTimeOutKey, 60)
         )
         {
             IsRequired = false,


### PR DESCRIPTION
- feature (NuGettier): add option '--timeout' (default 60s)
- refactor (NuGettier): make option '--timeout' default value depend on configuration defaults.timeout
- refactor (NuGettier): add option '--timeout' to 'upm [amalgamate] publish' commands
- refactor (NuGettier.Upm): wait for 'npm publish' process with timeout
