### PR TITLE
refactor (NuGettier.Upm): adapt Uri.SchemelessUri() extension method to always remove 'http(s)://' from given Uri

### DIFF
--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -11,6 +11,6 @@ public static class UriExtension
     /// <returns>Uri.AbsoluteUri without the scheme</returns>
     public static string SchemelessUri(this Uri uri)
     {
-        return uri.AbsoluteUri.Replace($"{uri.Scheme}//", "");
+        return uri.AbsoluteUri.Replace($"{uri.Scheme}//", "").Replace("https://", "").Replace("http://", "");
     }
 }


### PR DESCRIPTION
reason: in some cases, 'https://' did not get removed correctly. This ~~overcompensates~~ fixes the issue.
