### PR TITLE
refactor (NuGettier.Upm): improve generated .npmrc to include the registry

### DIFF
--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -44,6 +44,12 @@ public partial class Context
             outputDirectory.Create();
         }
 
+        if (targetNpmrc.Exists)
+        {
+            Logger.LogTrace("deleting existing .npmrc {0}", targetNpmrc.FullName);
+            targetNpmrc.Delete();
+        }
+
         if (token != null)
         {
             Logger.LogTrace("writing .npmrc to {0}", targetNpmrc.FullName);

--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -54,9 +54,20 @@ public partial class Context
         {
             Logger.LogTrace("writing .npmrc to {0}", targetNpmrc.FullName);
 
-            // format is "//${schemeless_registry}/:_authToken=${token}"
-            using (var npmrcWriter = new StreamWriter(targetNpmrc.OpenWrite()))
-                await npmrcWriter.WriteLineAsync($"//{Target.SchemelessUri()}:_authToken={token}");
+            using var npmrcWriter = new StreamWriter(targetNpmrc.OpenWrite());
+            var uriScope = Target.Scope();
+            if (string.IsNullOrEmpty(uriScope))
+            {
+                // `registry=${registry}/`
+                await npmrcWriter.WriteLineAsync($"registry={Target.ScopelessAbsoluteUri()}");
+            }
+            else
+            {
+                // `${uriScope}:registry=${registry}/`
+                await npmrcWriter.WriteLineAsync($"{uriScope}:registry={Target.ScopelessAbsoluteUri()}");
+            }
+            // `//${schemeless_registry}/:_authToken=${token}`
+            await npmrcWriter.WriteLineAsync($"//{Target.SchemelessUri()}:_authToken={token}");
         }
         else if (npmrc != null)
         {

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -13,4 +13,18 @@ public static class UriExtension
     {
         return uri.AbsoluteUri.Replace($"{uri.Scheme}//", "").Replace("https://", "").Replace("http://", "");
     }
+
+    /// <summary>
+    /// allows to get the schemeless Uri as required by `npm`
+    /// https://my-awesome-server/npmapi/@scope -> @scope
+    /// </summary>
+    /// <returns>the scope</returns>
+    public static string? Scope(this Uri uri)
+    {
+        var scopeIndex = uri.AbsolutePath.LastIndexOf(@"@");
+        if (scopeIndex < 0)
+            return null;
+
+        return uri.AbsolutePath.Substring(scopeIndex);
+    }
 }

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -5,13 +5,13 @@ namespace NuGettier.Upm;
 public static class UriExtension
 {
     /// <summary>
-    /// allows to get the schemeless Uri as required by `npm`
-    /// https://my-awesome-server/npmapi -> my-awesome-server/npmapi
+    /// returns the schemeless Uri as required by `npm`
+    /// https://my-awesome-server/npmapi/@scope -> my-awesome-server/npmapi
     /// </summary>
-    /// <returns>Uri.AbsoluteUri without the scheme</returns>
+    /// <returns>Uri.AbsoluteUri without the scheme nor the scope</returns>
     public static string SchemelessUri(this Uri uri)
     {
-        return uri.AbsoluteUri.Replace($"{uri.Scheme}//", "").Replace("https://", "").Replace("http://", "");
+        return uri.ScopelessAbsoluteUri().Replace($"{uri.Scheme}//", "").Replace("https://", "").Replace("http://", "");
     }
 
     /// <summary>

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -15,6 +15,20 @@ public static class UriExtension
     }
 
     /// <summary>
+    /// allows to get the scopeless Uri as required by `npm`
+    /// https://my-awesome-server/npmapi/@scope -> my-awesome-server/npmapi/
+    /// </summary>
+    /// <returns>Uri.AbsoluteUri without the scope</returns>
+    public static string ScopelessAbsoluteUri(this Uri uri)
+    {
+        var scope = uri.Scope();
+        if (string.IsNullOrEmpty(scope))
+            return uri.AbsoluteUri;
+
+        return uri.AbsoluteUri.Replace(scope, "");
+    }
+
+    /// <summary>
     /// allows to get the schemeless Uri as required by `npm`
     /// https://my-awesome-server/npmapi/@scope -> @scope
     /// </summary>


### PR DESCRIPTION
- feature (NuGettier.Upm): implement Uri.Scope() extension method that returns the NPM server scope
- feature (NuGettier.Upm): implement Uri.ScopelessAbsoluteUri() extension method that returns a Url without NPM server scope
- refactor (NuGettier.Upm): adapt Uri.SchemelessUri() extension method that to work with NPM server URLs that can optionally contain @scope
- fix (NuGettier.Upm): compensate .npmrc being partially overwritten by deleting it before writing to it
- refactor (NuGettier.Upm): improve generated .npmrc to include the registry
