### PR TITLE
refactor (NuGettier.Upm): fix writing to .npmrc file

### DIFF
--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -76,7 +76,7 @@ public partial class Context
             if (sourceNpmrc.Exists)
             {
                 Logger.LogTrace("copying {0} to {1}", sourceNpmrc.FullName, targetNpmrc.FullName);
-                await sourceNpmrc.OpenRead().CopyToAsync(targetNpmrc.OpenWrite());
+                sourceNpmrc.CopyTo(targetNpmrc.FullName, overwrite: true);
             }
             else
             {

--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -50,7 +50,7 @@ public partial class Context
             targetNpmrc.Delete();
         }
 
-        if (token != null)
+        if (!string.IsNullOrEmpty(token))
         {
             Logger.LogTrace("writing .npmrc to {0}", targetNpmrc.FullName);
 
@@ -69,7 +69,7 @@ public partial class Context
             // `//${schemeless_registry}/:_authToken=${token}`
             await npmrcWriter.WriteLineAsync($"//{Target.SchemelessUri()}:_authToken={token}");
         }
-        else if (npmrc != null)
+        else if (!string.IsNullOrEmpty(npmrc))
         {
             FileInfo sourceNpmrc = new(npmrc);
 

--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -90,7 +90,7 @@ public partial class Context
             }
         }
 
-        Assert.True(targetNpmrc.Exists);
+        Assert.True(Path.Exists(targetNpmrc.FullName));
         return targetNpmrc;
     }
 }

--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -53,7 +53,7 @@ public partial class Context
             cancellationToken: cancellationToken
         );
 
-        if (!npmrcFile.Exists)
+        if (!Path.Exists(npmrcFile.FullName))
         {
             Logger.TraceLocation().LogError("failed to write {0}", npmrcFile.FullName);
             return -1;


### PR DESCRIPTION
- refactor (NuGettier.Upm): change string null checks to string.IsNullOrEmpty() in Upm.Context.GenerateNpmrc()
- refactor (NuGettier.Upm): use FileInfo.CopyTo() to copy .npmrc in Upm.Context.GenerateNpmrc()
- refactor (NuGettier.Upm): use Path.Exists() to check if .npmrc file was properly written in Upm.Context.GenerateNpmrc()
- refactor (NuGettier.Upm): use Path.Exists() to check if .npmrc file was properly written in Upm.Context.PublishPackedUpmPackage()
