### PR TITLE
refactor (NuGettier): use Path.Exists() to check if .npmrc file was properly written in UpmNpmrc()

### DIFF
--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -90,6 +90,8 @@ public partial class Context
             }
         }
 
+        if (!Path.Exists(targetNpmrc.FullName))
+            Logger.TraceLocation().LogWarning("failed to write {0}", targetNpmrc.FullName);
         Assert.True(Path.Exists(targetNpmrc.FullName));
         return targetNpmrc;
     }

--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -44,7 +44,7 @@ public partial class Context
             outputDirectory.Create();
         }
 
-        if (targetNpmrc.Exists)
+        if (Path.Exists(targetNpmrc.FullName))
         {
             Logger.LogTrace("deleting existing .npmrc {0}", targetNpmrc.FullName);
             targetNpmrc.Delete();
@@ -72,8 +72,7 @@ public partial class Context
         else if (!string.IsNullOrEmpty(npmrc))
         {
             FileInfo sourceNpmrc = new(npmrc);
-
-            if (sourceNpmrc.Exists)
+            if (Path.Exists(sourceNpmrc.FullName))
             {
                 Logger.LogTrace("copying {0} to {1}", sourceNpmrc.FullName, targetNpmrc.FullName);
                 sourceNpmrc.CopyTo(targetNpmrc.FullName, overwrite: true);

--- a/NuGettier/UpmActions/UpmNpmrc.cs
+++ b/NuGettier/UpmActions/UpmNpmrc.cs
@@ -53,7 +53,7 @@ public partial class Program
             cancellationToken: cancellationToken
         );
 
-        if (!fileInfo.Exists)
+        if (!Path.Exists(fileInfo.FullName))
         {
             Logger.LogError("failed to generate .npmrc {0}", fileInfo.FullName);
             return 1;


### PR DESCRIPTION
- refactor (NuGettier.Upm): issue warning before hard-crash when .npmrc has not been written in Upm.Context.GenerateNpmrc()
- refactor (NuGettier): use Path.Exists() to check if .npmrc file was properly written in UpmNpmrc()
- refactor (NuGettier.Upm): use Path.Exists() to check if source .npmrc exists prior to copy in Upm.Context.GenerateNpmrc()
