### PR TITLE
refactor (NuGettier et al): restore usage of FileInfo.Exists over Path.Exists() after using FileInfo.Refresh() to update the cache

### DIFF
--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -44,7 +44,7 @@ public partial class Context
             outputDirectory.Create();
         }
 
-        if (Path.Exists(targetNpmrc.FullName))
+        if (targetNpmrc.Exists)
         {
             Logger.LogTrace("deleting existing .npmrc {0}", targetNpmrc.FullName);
             targetNpmrc.Delete();
@@ -74,7 +74,7 @@ public partial class Context
         else if (!string.IsNullOrEmpty(npmrc))
         {
             FileInfo sourceNpmrc = new(npmrc);
-            if (Path.Exists(sourceNpmrc.FullName))
+            if (sourceNpmrc.Exists)
             {
                 Logger.LogTrace("copying {0} to {1}", sourceNpmrc.FullName, targetNpmrc.FullName);
                 sourceNpmrc.CopyTo(targetNpmrc.FullName, overwrite: true);
@@ -93,9 +93,9 @@ public partial class Context
         }
 
         targetNpmrc.Refresh();
-        if (!Path.Exists(targetNpmrc.FullName))
+        if (!targetNpmrc.Exists)
             Logger.TraceLocation().LogWarning("failed to write {0}", targetNpmrc.FullName);
-        Assert.True(Path.Exists(targetNpmrc.FullName));
+        Assert.True(targetNpmrc.Exists);
         return targetNpmrc;
     }
 }

--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -48,6 +48,7 @@ public partial class Context
         {
             Logger.LogTrace("deleting existing .npmrc {0}", targetNpmrc.FullName);
             targetNpmrc.Delete();
+            targetNpmrc.Refresh();
         }
 
         if (!string.IsNullOrEmpty(token))
@@ -68,6 +69,7 @@ public partial class Context
             }
             // `//${schemeless_registry}/:_authToken=${token}`
             npmrcWriter.WriteLine($"//{Target.SchemelessUri()}:_authToken={token}");
+            targetNpmrc.Refresh();
         }
         else if (!string.IsNullOrEmpty(npmrc))
         {
@@ -76,6 +78,7 @@ public partial class Context
             {
                 Logger.LogTrace("copying {0} to {1}", sourceNpmrc.FullName, targetNpmrc.FullName);
                 sourceNpmrc.CopyTo(targetNpmrc.FullName, overwrite: true);
+                targetNpmrc.Refresh();
             }
             else
             {
@@ -89,6 +92,7 @@ public partial class Context
             }
         }
 
+        targetNpmrc.Refresh();
         if (!Path.Exists(targetNpmrc.FullName))
             Logger.TraceLocation().LogWarning("failed to write {0}", targetNpmrc.FullName);
         Assert.True(Path.Exists(targetNpmrc.FullName));

--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -54,6 +54,7 @@ public partial class Context
             cancellationToken: cancellationToken
         );
 
+        npmrcFile.Refresh();
         if (!Path.Exists(npmrcFile.FullName))
         {
             Logger.TraceLocation().LogError("failed to write {0}", npmrcFile.FullName);

--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -55,7 +55,7 @@ public partial class Context
         );
 
         npmrcFile.Refresh();
-        if (!Path.Exists(npmrcFile.FullName))
+        if (!npmrcFile.Exists)
         {
             Logger.TraceLocation().LogError("failed to write {0}", npmrcFile.FullName);
             return -1;

--- a/NuGettier/UpmActions/UpmNpmrc.cs
+++ b/NuGettier/UpmActions/UpmNpmrc.cs
@@ -53,6 +53,7 @@ public partial class Program
             cancellationToken: cancellationToken
         );
 
+        fileInfo.Refresh();
         if (!Path.Exists(fileInfo.FullName))
         {
             Logger.LogError("failed to generate .npmrc {0}", fileInfo.FullName);

--- a/NuGettier/UpmActions/UpmNpmrc.cs
+++ b/NuGettier/UpmActions/UpmNpmrc.cs
@@ -54,7 +54,7 @@ public partial class Program
         );
 
         fileInfo.Refresh();
-        if (!Path.Exists(fileInfo.FullName))
+        if (!fileInfo.Exists)
         {
             Logger.LogError("failed to generate .npmrc {0}", fileInfo.FullName);
             return 1;


### PR DESCRIPTION
- refactor (NuGettier.Upm): refresh target npmrc FileInfo after every affecting action in Upm.Context.GenerateNpmrc()
- refactor (NuGettier.Upm): refresh target npmrc FileInfo after every affecting action in Upm.Context.PublishPackedUpmPackage()
- refactor (NuGettier): refresh target npmrc FileInfo after every affecting action in UpmNpmrc()
- refactor (NuGettier.Upm): restore usage of FileInfo.Exists over Path.Exists() in Upm.Context.GenerateNpmrc()
- refactor (NuGettier.Upm): restore usage of FileInfo.Exists over Path.Exists() in Upm.Context.PublishPackedUpmPackage()
- refactor (NuGettier): restore usage of FileInfo.Exists over Path.Exists() in UpmNpmrc()
