### PR TITLE
refactor (NuGettier.Upm): improve parameters passed to 'npm publish'

### DIFF
--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -96,8 +96,22 @@ public partial class Context
         }
 
         targetNpmrc.Refresh();
-        if (!targetNpmrc.Exists)
+        if (targetNpmrc.Exists)
+        {
+            using (var targetStream = targetNpmrc.OpenRead())
+            using (var npmrcReader = new StreamReader(targetStream))
+            {
+                Logger.LogInformation(
+                    "generated {0} with following contents:\n{1}",
+                    targetNpmrc.FullName,
+                    await npmrcReader.ReadToEndAsync()
+                );
+            }
+        }
+        else
+        {
             Logger.TraceLocation().LogWarning("failed to write {0}", targetNpmrc.FullName);
+        }
         Assert.True(targetNpmrc.Exists);
         return targetNpmrc;
     }

--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -80,7 +80,7 @@ public partial class Context
                 $"--registry={Target.SchemelessUri()}",
                 dryRun ? "--dry-run" : string.Empty,
                 "--verbose",
-                $"--access {packageAccessLevel.ToString().ToLowerInvariant()}"
+                $"--access={packageAccessLevel.ToString().ToLowerInvariant()}"
             );
 
             StringBuilder stdoutBuilder = new();

--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -90,7 +90,7 @@ public partial class Context
                 {
                     lock (stdoutLocker)
                     {
-                        var dataTrimmed = args.Data.Trim();
+                        var dataTrimmed = args.Data?.Trim() ?? string.Empty;
                         stdoutBuilder.AppendLine(dataTrimmed);
                         Logger.LogInformation("NPM stdout: {0}", dataTrimmed);
                     }
@@ -104,7 +104,7 @@ public partial class Context
                 {
                     lock (stderrLocker)
                     {
-                        var dataTrimmed = args.Data.Trim();
+                        var dataTrimmed = args.Data?.Trim() ?? string.Empty;
                         stderrBuilder.AppendLine(dataTrimmed);
                         Logger.LogInformation("NPM stderr: {0}", dataTrimmed);
                     }

--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -64,6 +64,8 @@ public partial class Context
         int exitCode = -2;
         try
         {
+            var targetScope = Target.Scope();
+
             Logger.LogTrace("creating process for `npm publish`");
             using var process = new System.Diagnostics.Process();
             process.StartInfo.UseShellExecute = false;
@@ -77,7 +79,9 @@ public partial class Context
                 " ",
                 "publish",
                 packageFile.Name,
-                $"--registry={Target.ScopelessAbsoluteUri()}",
+                string.IsNullOrEmpty(targetScope)
+                    ? $"--registry={Target.ScopelessAbsoluteUri()}"
+                    : $"--scope={targetScope}",
                 dryRun ? "--dry-run" : string.Empty,
                 "--verbose",
                 $"--access={packageAccessLevel.ToString().ToLowerInvariant()}"

--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -77,7 +77,7 @@ public partial class Context
                 " ",
                 "publish",
                 packageFile.Name,
-                $"--registry={Target.SchemelessUri()}",
+                $"--registry={Target.ScopelessAbsoluteUri()}",
                 dryRun ? "--dry-run" : string.Empty,
                 "--verbose",
                 $"--access={packageAccessLevel.ToString().ToLowerInvariant()}"

--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -148,7 +148,8 @@ public partial class Context
         }
         catch (Exception e)
         {
-            Logger.LogError($"NPM: {e.Message}");
+            Logger.TraceLocation().LogError($"NPM: {e.Message}");
+            return -3;
         }
 
         return exitCode;


### PR DESCRIPTION
- refactor (NuGettier.Upm): pass '--access=<access level>' to 'npm publish' in Upm.Context.PublishPackedUpmPackage()
- refactor (NuGettier.Upm): pass '--registry' as absolute URI without scope to 'npm publish' in Upm.Context.PublishPackedUpmPackage()
- refactor (NuGettier.Upm): fix potential null pointer access in 'DataReceivedEventHandler' delegates in Upm.Context.PublishPackedUpmPackage()
- refactor (NuGettier.Upm): use 'npm publish' with '--scope' if target registry URI contains scope, else absolute registry Uri in Upm.Context.PublishPackedUpmPackage()
- refactor (NuGettier.Upm): return -3 if any exception happened in 'npm publish' process in Upm.Context.PublishPackedUpmPackage()
- refactor (NuGettier.Upm): log contents of generated .npmrc file
