### PR TITLE
refactor (NuGettier.Upm): improve stdout/stderr log capture from 'npm publish' and re-output

### DIFF
--- a/NuGettier.Core/Extensions/ILoggerExtension.cs
+++ b/NuGettier.Core/Extensions/ILoggerExtension.cs
@@ -112,4 +112,11 @@ public static class ILoggerExtension
         string? message,
         params object?[] args
     ) => await logger.LogAsync(LogLevel.Warning, cancellationToken, message, args);
+
+    public static async Task LogErrorAsync(
+        this ILogger logger,
+        CancellationToken cancellationToken,
+        string? message,
+        params object?[] args
+    ) => await logger.LogAsync(LogLevel.Error, cancellationToken, message, args);
 }

--- a/NuGettier.Core/Extensions/ILoggerExtension.cs
+++ b/NuGettier.Core/Extensions/ILoggerExtension.cs
@@ -84,4 +84,11 @@ public static class ILoggerExtension
         await Task.Run(() => logger.Log(logLevel, message, args));
         await Task.Delay(1_000, cancellationToken);
     }
+
+    public static async Task LogTraceAsync(
+        this ILogger logger,
+        CancellationToken cancellationToken,
+        string? message,
+        params object?[] args
+    ) => await logger.LogAsync(LogLevel.Trace, cancellationToken, message, args);
 }

--- a/NuGettier.Core/Extensions/ILoggerExtension.cs
+++ b/NuGettier.Core/Extensions/ILoggerExtension.cs
@@ -105,4 +105,11 @@ public static class ILoggerExtension
         string? message,
         params object?[] args
     ) => await logger.LogAsync(LogLevel.Information, cancellationToken, message, args);
+
+    public static async Task LogWarningAsync(
+        this ILogger logger,
+        CancellationToken cancellationToken,
+        string? message,
+        params object?[] args
+    ) => await logger.LogAsync(LogLevel.Warning, cancellationToken, message, args);
 }

--- a/NuGettier.Core/Extensions/ILoggerExtension.cs
+++ b/NuGettier.Core/Extensions/ILoggerExtension.cs
@@ -119,4 +119,11 @@ public static class ILoggerExtension
         string? message,
         params object?[] args
     ) => await logger.LogAsync(LogLevel.Error, cancellationToken, message, args);
+
+    public static async Task LogCriticalAsync(
+        this ILogger logger,
+        CancellationToken cancellationToken,
+        string? message,
+        params object?[] args
+    ) => await logger.LogAsync(LogLevel.Critical, cancellationToken, message, args);
 }

--- a/NuGettier.Core/Extensions/ILoggerExtension.cs
+++ b/NuGettier.Core/Extensions/ILoggerExtension.cs
@@ -91,4 +91,11 @@ public static class ILoggerExtension
         string? message,
         params object?[] args
     ) => await logger.LogAsync(LogLevel.Trace, cancellationToken, message, args);
+
+    public static async Task LogDebugAsync(
+        this ILogger logger,
+        CancellationToken cancellationToken,
+        string? message,
+        params object?[] args
+    ) => await logger.LogAsync(LogLevel.Debug, cancellationToken, message, args);
 }

--- a/NuGettier.Core/Extensions/ILoggerExtension.cs
+++ b/NuGettier.Core/Extensions/ILoggerExtension.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 public static class ILoggerExtension
@@ -69,5 +71,17 @@ public static class ILoggerExtension
     {
         logger.LogDebug("{0}.{1}() {2}:{3}", obj.GetType().FullName, memberName, sourceFilePath, sourceLineNumber);
         return logger;
+    }
+
+    public static async Task LogAsync(
+        this ILogger logger,
+        LogLevel logLevel,
+        CancellationToken cancellationToken,
+        string? message,
+        params object?[] args
+    )
+    {
+        await Task.Run(() => logger.Log(logLevel, message, args));
+        await Task.Delay(1_000, cancellationToken);
     }
 }

--- a/NuGettier.Core/Extensions/ILoggerExtension.cs
+++ b/NuGettier.Core/Extensions/ILoggerExtension.cs
@@ -98,4 +98,11 @@ public static class ILoggerExtension
         string? message,
         params object?[] args
     ) => await logger.LogAsync(LogLevel.Debug, cancellationToken, message, args);
+
+    public static async Task LogInformationAsync(
+        this ILogger logger,
+        CancellationToken cancellationToken,
+        string? message,
+        params object?[] args
+    ) => await logger.LogAsync(LogLevel.Information, cancellationToken, message, args);
 }

--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -98,15 +98,11 @@ public partial class Context
         targetNpmrc.Refresh();
         if (targetNpmrc.Exists)
         {
-            using (var targetStream = targetNpmrc.OpenRead())
-            using (var npmrcReader = new StreamReader(targetStream))
-            {
-                Logger.LogInformation(
-                    "generated {0} with following contents:\n{1}",
-                    targetNpmrc.FullName,
-                    await npmrcReader.ReadToEndAsync()
-                );
-            }
+            Logger.LogInformation(
+                "generated {0} with following contents:\n{1}",
+                targetNpmrc.FullName,
+                await File.ReadAllTextAsync(targetNpmrc.FullName, cancellationToken)
+            );
         }
         else
         {

--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -156,7 +156,7 @@ public partial class Context
         }
         catch (Exception e)
         {
-            Logger.TraceLocation().LogError($"NPM: {e.Message}");
+            Logger.TraceLocation().LogCritical("NPM [exception]: {0}", e.Message);
             return -3;
         }
 


### PR DESCRIPTION
- feature (NuGettier.Core): implement ILogger.LogAsync() extension method
- feature (NuGettier.Core): implement ILogger.LogTraceAsync() extension method
- feature (NuGettier.Core): implement ILogger.LogDebugAsync() extension method
- feature (NuGettier.Core): implement ILogger.LogInformationAsync() extension method
- feature (NuGettier.Core): implement ILogger.LogWarningAsync() extension method
- feature (NuGettier.Core): implement ILogger.LogErrorAsync() extension method
- feature (NuGettier.Core): implement ILogger.LogCriticalAsync() extension method
- refactor (NuGettier.Upm): simplify written .npmrc readback in Upm.Context.GenerateNpmrc()
- refactor (NuGettier.Upm): improve critical log message for caught exceptions in Upm.Context.PublishPackedUpmPackage()
- refactor (NuGettier.Upm): improve stdout/stderr log capture from 'npm publish' and re-output in Upm.Context.PublishPackedUpmPackage()
