### PR TITLE
refactor (NuGettier.Upm): change where and how version suffices are applied

### DIFF
--- a/NuGettier.Amalgamate/Context/GetPackageJson.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageJson.cs
@@ -27,6 +27,7 @@ public partial class Context
         string packageIdVersion,
         bool preRelease,
         string? prereleaseSuffix,
+        string? buildmetaSuffix,
         CancellationToken cancellationToken
     )
     {
@@ -36,6 +37,7 @@ public partial class Context
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,
             prereleaseSuffix: prereleaseSuffix,
+            buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken
         );
     }

--- a/NuGettier.Amalgamate/Context/GetPackageJson.cs
+++ b/NuGettier.Amalgamate/Context/GetPackageJson.cs
@@ -26,6 +26,7 @@ public partial class Context
     public override async Task<Upm.PackageJson?> GetPackageJson(
         string packageIdVersion,
         bool preRelease,
+        string? prereleaseSuffix,
         CancellationToken cancellationToken
     )
     {
@@ -34,6 +35,7 @@ public partial class Context
         return await base.GetPackageJson(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,
+            prereleaseSuffix: prereleaseSuffix,
             cancellationToken: cancellationToken
         );
     }

--- a/NuGettier.Amalgamate/Context/Utility.cs
+++ b/NuGettier.Amalgamate/Context/Utility.cs
@@ -17,7 +17,8 @@ public partial class Context
 {
     public override Upm.PackageJson PatchPackageJson(
         Upm.PackageJson packageJson,
-        string? prereleaseSuffix = null
+        string? prereleaseSuffix = null,
+        string? buildmetaSuffix = null
     )
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());

--- a/NuGettier.Amalgamate/Context/Utility.cs
+++ b/NuGettier.Amalgamate/Context/Utility.cs
@@ -15,7 +15,10 @@ namespace NuGettier.Amalgamate;
 
 public partial class Context
 {
-    public override Upm.PackageJson PatchPackageJson(Upm.PackageJson packageJson)
+    public override Upm.PackageJson PatchPackageJson(
+        Upm.PackageJson packageJson,
+        string? prereleaseSuffix = null
+    )
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
         var includedDependencies = packageJson

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -45,6 +45,6 @@ public partial class Context
         if (packageJson == null)
             return null;
 
-        return PatchPackageJson(packageJson);
+        return PatchPackageJson(packageJson: packageJson, prereleaseSuffix: prereleaseSuffix);
     }
 }

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -26,6 +26,7 @@ public partial class Context
         string packageIdVersion,
         bool preRelease,
         string? prereleaseSuffix,
+        string? buildmetaSuffix,
         CancellationToken cancellationToken
     )
     {

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -25,6 +25,7 @@ public partial class Context
     public virtual async Task<PackageJson?> GetPackageJson(
         string packageIdVersion,
         bool preRelease,
+        string? prereleaseSuffix,
         CancellationToken cancellationToken
     )
     {

--- a/NuGettier.Upm/Context/GetPackageJson.cs
+++ b/NuGettier.Upm/Context/GetPackageJson.cs
@@ -45,6 +45,10 @@ public partial class Context
         if (packageJson == null)
             return null;
 
-        return PatchPackageJson(packageJson: packageJson, prereleaseSuffix: prereleaseSuffix);
+        return PatchPackageJson(
+            packageJson: packageJson,
+            prereleaseSuffix: prereleaseSuffix,
+            buildmetaSuffix: buildmetaSuffix
+        );
     }
 }

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -40,6 +40,7 @@ public partial class Context
         var packageJson = await GetPackageJson(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,
+            prereleaseSuffix: prereleaseSuffix,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -48,12 +48,6 @@ public partial class Context
         if (packageJson == null)
             return null;
 
-        // add version suffixes
-        if (!string.IsNullOrEmpty(prereleaseSuffix))
-            packageJson.Version += $"-{prereleaseSuffix}";
-        if (!string.IsNullOrEmpty(buildmetaSuffix))
-            packageJson.Version += $"+{buildmetaSuffix}";
-
         // fetch package contents for NuGet
         using var packageStream = await FetchPackage(
             packageIdVersion: packageIdVersion,

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -41,6 +41,7 @@ public partial class Context
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,
             prereleaseSuffix: prereleaseSuffix,
+            buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -65,7 +65,7 @@ public partial class Context
         var packageRule = GetPackageRule(packageJson.Name);
 
         // patch packageJson.Name, .Version and .MinUnityVersion
-        packageJson.Name = PatchPackageId(packageJson.Name);
+        packageJson.Name = PatchPackageId(packageId: packageJson.Name);
         packageJson.Version = PatchPackageVersion(
             packageId: packageJson.Name,
             packageVersion: packageJson.Version,

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -128,10 +128,23 @@ public partial class Context
             ? packageRule.Version
             : Context.DefaultPackageRule.Version;
 
-        var result = Regex.Match(packageVersion, versionRegex).Value;
-        Logger.LogTrace($"after: {packageId}: {result}");
+        var resultVersion = Regex.Match(packageVersion, versionRegex).Value;
+        Logger.LogTrace($"after: {packageId}: {resultVersion}");
 
-        return result;
+        // add version suffixes
+        if (!string.IsNullOrEmpty(prereleaseSuffix))
+        {
+            resultVersion += $"-{prereleaseSuffix}";
+            Logger.LogDebug("adding: -{0} -> {1}", prereleaseSuffix, resultVersion);
+        }
+
+        if (!string.IsNullOrEmpty(buildmetaSuffix))
+        {
+            resultVersion += $"+{buildmetaSuffix}";
+            Logger.LogDebug("adding: +{0} -> {1}", buildmetaSuffix, resultVersion);
+        }
+
+        return resultVersion;
     }
 
     protected virtual IDictionary<string, string> PatchPackageDependencies(IDictionary<string, string> dependencies)

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -67,7 +67,8 @@ public partial class Context
         // patch packageJson.Name, .Version and .MinUnityVersion
         packageJson.Name = PatchPackageId(packageJson.Name);
         packageJson.Version = PatchPackageVersion(packageJson.Name, packageJson.Version,
-            prereleaseSuffix: prereleaseSuffix
+            prereleaseSuffix: prereleaseSuffix,
+            buildmetaSuffix: buildmetaSuffix
         );
         packageJson.MinUnityVersion = MinUnityVersion;
 
@@ -113,7 +114,8 @@ public partial class Context
     protected virtual string PatchPackageVersion(
         string packageId,
         string packageVersion,
-        string? prereleaseSuffix = null
+        string? prereleaseSuffix = null,
+        string? buildmetaSuffix = null
     )
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -66,7 +66,9 @@ public partial class Context
 
         // patch packageJson.Name, .Version and .MinUnityVersion
         packageJson.Name = PatchPackageId(packageJson.Name);
-        packageJson.Version = PatchPackageVersion(packageJson.Name, packageJson.Version,
+        packageJson.Version = PatchPackageVersion(
+            packageId: packageJson.Name,
+            packageVersion: packageJson.Version,
             prereleaseSuffix: prereleaseSuffix,
             buildmetaSuffix: buildmetaSuffix
         );

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -66,7 +66,9 @@ public partial class Context
 
         // patch packageJson.Name, .Version and .MinUnityVersion
         packageJson.Name = PatchPackageId(packageJson.Name);
-        packageJson.Version = PatchPackageVersion(packageJson.Name, packageJson.Version);
+        packageJson.Version = PatchPackageVersion(packageJson.Name, packageJson.Version,
+            prereleaseSuffix: prereleaseSuffix
+        );
         packageJson.MinUnityVersion = MinUnityVersion;
 
         // filter and patch dependencies' name and version
@@ -108,7 +110,11 @@ public partial class Context
         return result;
     }
 
-    protected virtual string PatchPackageVersion(string packageId, string packageVersion)
+    protected virtual string PatchPackageVersion(
+        string packageId,
+        string packageVersion,
+        string? prereleaseSuffix = null
+    )
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
 

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -55,7 +55,8 @@ public partial class Context
 
     public virtual PackageJson PatchPackageJson(
         PackageJson packageJson,
-        string? prereleaseSuffix = null
+        string? prereleaseSuffix = null,
+        string? buildmetaSuffix = null
     )
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -53,7 +53,10 @@ public partial class Context
         return packageRule;
     }
 
-    public virtual PackageJson PatchPackageJson(PackageJson packageJson)
+    public virtual PackageJson PatchPackageJson(
+        PackageJson packageJson,
+        string? prereleaseSuffix = null
+    )
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
 

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -73,6 +73,7 @@ public partial class Program
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,
             prereleaseSuffix: prereleaseSuffix,
+            buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier/UpmActions/UpmInfo.cs
+++ b/NuGettier/UpmActions/UpmInfo.cs
@@ -72,6 +72,7 @@ public partial class Program
         var packageJson = await context.GetPackageJson(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,
+            prereleaseSuffix: prereleaseSuffix,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -73,6 +73,7 @@ public partial class Program
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,
             prereleaseSuffix: prereleaseSuffix,
+            buildmetaSuffix: buildmetaSuffix,
             cancellationToken: cancellationToken
         );
 

--- a/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
+++ b/NuGettier/UpmAmalgamateActions/AmalgamateInfo.cs
@@ -72,6 +72,7 @@ public partial class Program
         var packageJson = await context.GetPackageJson(
             packageIdVersion: packageIdVersion,
             preRelease: preRelease,
+            prereleaseSuffix: prereleaseSuffix,
             cancellationToken: cancellationToken
         );
 


### PR DESCRIPTION
- refactor (NuGettier.Upm): add argument 'prereleaseSuffix' to Upm.Context.GetPackageJson()
- refactor (NuGettier.Upm): add argument 'buildmetaSuffix' to Upm.Context.GetPackageJson()
- refactor (NuGettier.Upm): add argument 'prereleaseSuffix' to Upm.Context.PatchPackageJson()
- refactor (NuGettier.Upm): add argument 'buildmetaSuffix' to Upm.Context.PatchPackageJson()
- refactor (NuGettier.Upm): add argument 'prereleaseSuffix' to Upm.Context.PatchPackageVersion()
- refactor (NuGettier.Upm): add argument 'buildmetaSuffix' to Upm.Context.PatchPackageVersion()
- refactor (NuGettier.Upm): call Upm.Context.PatchPackageVersion() with named arguments
- refactor (NuGettier.Upm): call Upm.Context.PatchPackageId() with named arguments
- refactor (NuGettier.Upm): add prerelease and buildmeta suffices to result version in Upm.Context.PatchPackageVersion()
- refactor (NuGettier.Upm): remove adding prerelease and buildmeta suffices to result version in Upm.Context.PackUpmPackage()
