### PR TITLE
refactor (NuGettier.Upm): improve metafile and Guid generation

### DIFF
--- a/NuGettier.Upm/MetaGen/Guid.cs
+++ b/NuGettier.Upm/MetaGen/Guid.cs
@@ -22,6 +22,11 @@ struct Guid
         hash = xxHash128.ComputeHash(value, seedHash);
     }
 
+    public Guid(ulong seedHash, string value)
+    {
+        hash = xxHash128.ComputeHash(value, seedHash);
+    }
+
     public override readonly string ToString()
     {
         return $"{hash.high64:x8}{hash.low64:x8}";

--- a/NuGettier.Upm/MetaGen/Guid.cs
+++ b/NuGettier.Upm/MetaGen/Guid.cs
@@ -9,6 +9,8 @@ struct Guid
 {
     public uint128 hash;
 
+    public static ulong SeedHash(string seed) => xxHash3.ComputeHash(seed);
+
     public Guid()
     {
         hash = default;
@@ -16,7 +18,7 @@ struct Guid
 
     public Guid(string seed, string value)
     {
-        var seedHash = xxHash3.ComputeHash(seed);
+        var seedHash = SeedHash(seed);
         hash = xxHash128.ComputeHash(value, seedHash);
     }
 

--- a/NuGettier.Upm/MetaGen/Guid.cs
+++ b/NuGettier.Upm/MetaGen/Guid.cs
@@ -17,10 +17,7 @@ struct Guid
     }
 
     public Guid(string seed, string value)
-    {
-        var seedHash = SeedHash(seed);
-        hash = xxHash128.ComputeHash(value, seedHash);
-    }
+        : this(seedHash: SeedHash(seed), value) { }
 
     public Guid(ulong seedHash, string value)
     {

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -7,6 +7,7 @@ namespace NuGettier.Upm;
 public interface IMetaFactory
 {
     string GenerateFolderMeta(string seed, string dirname);
+    string GenerateFolderMeta(ulong seedHash, string dirname);
     string GenerateFileMeta(string seed, string filename);
 }
 

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -43,7 +43,7 @@ public class MetaFactory : IMetaFactory
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
 
-        var guid = new MetaGen.Guid(seed, filename);
+        var guid = new MetaGen.Guid(Guid.SeedHash(seed), filename);
         var metaTemplate = Handlebars.Compile(
             Path.GetExtension(filename).EndsWith(".dll")
                 ? EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.assembly.meta")

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -82,4 +82,26 @@ public class MetaFactory : IMetaFactory
 
         return metaContents;
     }
+
+    public virtual string GenerateFileMeta(ulong seedHash, string filename)
+    {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
+        var guid = new MetaGen.Guid(seedHash, filename);
+        var metaTemplate = Handlebars.Compile(
+            Path.GetExtension(filename).EndsWith(".dll")
+                ? EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.assembly.meta")
+                : EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.template.meta")
+        );
+        var metaContents = metaTemplate(new { guid = guid });
+        Logger.LogDebug(
+            "generated meta file for file {0} with seed hash {1} (GUID: {2}):\n{3}",
+            filename,
+            seedHash,
+            guid,
+            metaContents
+        );
+
+        return metaContents;
+    }
 }

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -23,7 +23,7 @@ public class MetaFactory : IMetaFactory
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
 
-        var guid = new MetaGen.Guid(seed, dirname);
+        var guid = new MetaGen.Guid(Guid.SeedHash(seed), dirname);
         var metaTemplate = Handlebars.Compile(
             EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.folder.meta")
         );

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -50,23 +50,7 @@ public class MetaFactory : IMetaFactory
     public virtual string GenerateFileMeta(string seed, string filename)
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
-
-        var guid = new MetaGen.Guid(Guid.SeedHash(seed), filename);
-        var metaTemplate = Handlebars.Compile(
-            Path.GetExtension(filename).EndsWith(".dll")
-                ? EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.assembly.meta")
-                : EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.template.meta")
-        );
-        var metaContents = metaTemplate(new { guid = guid });
-        Logger.LogDebug(
-            "generated meta file for file {0} with seed {1} (GUID: {2}):\n{3}",
-            filename,
-            seed,
-            guid,
-            metaContents
-        );
-
-        return metaContents;
+        return GenerateFileMeta(MetaGen.Guid.SeedHash(seed), filename);
     }
 
     public virtual string GenerateFileMeta(ulong seedHash, string filename)

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -40,6 +40,26 @@ public class MetaFactory : IMetaFactory
         return metaContents;
     }
 
+    public virtual string GenerateFolderMeta(ulong seedHash, string dirname)
+    {
+        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
+
+        var guid = new MetaGen.Guid(seedHash, dirname);
+        var metaTemplate = Handlebars.Compile(
+            EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.folder.meta")
+        );
+        var metaContents = metaTemplate(new { guid = guid });
+        Logger.LogDebug(
+            "generated meta file for folder {0} with seed hash {1} (GUID: {2}):\n{3}",
+            dirname,
+            seedHash,
+            guid,
+            metaContents
+        );
+
+        return metaContents;
+    }
+
     public virtual string GenerateFileMeta(string seed, string filename)
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -9,6 +9,7 @@ public interface IMetaFactory
     string GenerateFolderMeta(string seed, string dirname);
     string GenerateFolderMeta(ulong seedHash, string dirname);
     string GenerateFileMeta(string seed, string filename);
+    string GenerateFileMeta(ulong seedHash, string filename);
 }
 
 public class MetaFactory : IMetaFactory

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -24,21 +24,7 @@ public class MetaFactory : IMetaFactory
     public virtual string GenerateFolderMeta(string seed, string dirname)
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
-
-        var guid = new MetaGen.Guid(Guid.SeedHash(seed), dirname);
-        var metaTemplate = Handlebars.Compile(
-            EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.folder.meta")
-        );
-        var metaContents = metaTemplate(new { guid = guid });
-        Logger.LogDebug(
-            "generated meta file for folder {0} with seed {1} (GUID: {2}):\n{3}",
-            dirname,
-            seed,
-            guid,
-            metaContents
-        );
-
-        return metaContents;
+        return GenerateFolderMeta(MetaGen.Guid.SeedHash(seed), dirname);
     }
 
     public virtual string GenerateFolderMeta(ulong seedHash, string dirname)


### PR DESCRIPTION
- refactor (NuGettier.Upm): wrap Guid seed hash computation in static method
- feature (NuGettier.Upm): implement Guid.ctor taking the seed hash directly
- refactor (NuGettier.Upm): redirect Guid.ctor(seed, value) to Guid.ctor(seedHash, value)
- refactor (NuGettier.Upm): compute seed hash directly before passing to Guid.ctor in MetaFactory.GenerateFolderMeta()
- refactor (NuGettier.Upm): compute seed hash directly before passing to Guid.ctor in MetaFactory.GenerateFileMeta()
- feature (NuGettier.Upm): add interface method IMetaFactory.GenerateFolderMeta() taking seed hash instead of seed string
- refactor (NuGettier.Upm): implement MetaFactory.GenerateFolderMeta() taking seed hash instead of seed string
- feature (NuGettier.Upm): add interface method IMetaFactory.GenerateFileMeta() taking seed hash instead of seed string
- refactor (NuGettier.Upm): implement MetaFactory.GenerateFileMeta() taking seed hash instead of seed string
- refactor (NuGettier.Upm): simplify MetaFactory.GenerateFolderMeta(), seed string version
- refactor (NuGettier.Upm): simplify MetaFactory.GenerateFileMeta(), seed string version
