### PR TITLE
refactor (NuGettier.Upm): simplify IMetaFactory to handle seed and guid computation internally

### DIFF
--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -105,7 +105,7 @@ public partial class Context
         Logger.LogDebug("generated package.json:\n{0}", packageJsonString);
 
         // add meta files
-        files.AddMetaFiles(seed: packageJson.Name, metaFactory: new MetaFactory(LoggerFactory));
+        files.AddMetaFiles(metaFactory: new MetaFactory(seed: packageJson.Name, LoggerFactory));
 
         var packageIdentifier = $"{packageJson.Name}-{packageJson.Version}";
         return new Tuple<string, FileDictionary>(packageIdentifier, files);

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -23,25 +23,20 @@ public class MetaFactory : IMetaFactory
         Logger = loggerFactory.CreateLogger<MetaFactory>();
     }
 
-    public virtual string GenerateFolderMeta(string seed, string dirname)
-    {
-        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
-        return GenerateFolderMeta(MetaGen.Guid.SeedHash(seed), dirname);
-    }
-
-    public virtual string GenerateFolderMeta(ulong seedHash, string dirname)
+    public virtual string GenerateFolderMeta(string dirname)
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
 
-        var guid = new MetaGen.Guid(seedHash, dirname);
+        var guid = new MetaGen.Guid(SeedHash, dirname);
         var metaTemplate = Handlebars.Compile(
             EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.folder.meta")
         );
         var metaContents = metaTemplate(new { guid = guid });
         Logger.LogDebug(
-            "generated meta file for folder {0} with seed hash {1} (GUID: {2}):\n{3}",
+            "generated meta file for folder {0} with seed {1} (hash {2:x}) (GUID: {3}):\n{4}",
             dirname,
-            seedHash,
+            Seed,
+            SeedHash,
             guid,
             metaContents
         );
@@ -49,17 +44,11 @@ public class MetaFactory : IMetaFactory
         return metaContents;
     }
 
-    public virtual string GenerateFileMeta(string seed, string filename)
-    {
-        using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
-        return GenerateFileMeta(MetaGen.Guid.SeedHash(seed), filename);
-    }
-
-    public virtual string GenerateFileMeta(ulong seedHash, string filename)
+    public virtual string GenerateFileMeta(string filename)
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
 
-        var guid = new MetaGen.Guid(seedHash, filename);
+        var guid = new MetaGen.Guid(SeedHash, filename);
         var metaTemplate = Handlebars.Compile(
             Path.GetExtension(filename).EndsWith(".dll")
                 ? EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.assembly.meta")
@@ -67,9 +56,10 @@ public class MetaFactory : IMetaFactory
         );
         var metaContents = metaTemplate(new { guid = guid });
         Logger.LogDebug(
-            "generated meta file for file {0} with seed hash {1} (GUID: {2}):\n{3}",
+            "generated meta file for file {0} with seed {1} (hash {2:x}) (GUID: {3}):\n{4}",
             filename,
-            seedHash,
+            Seed,
+            SeedHash,
             guid,
             metaContents
         );

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -13,9 +13,13 @@ public interface IMetaFactory
 public class MetaFactory : IMetaFactory
 {
     protected readonly Microsoft.Extensions.Logging.ILogger Logger;
+    protected string Seed;
+    protected ulong SeedHash;
 
-    public MetaFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory)
+    public MetaFactory(string seed, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory)
     {
+        Seed = seed;
+        SeedHash = MetaGen.Guid.SeedHash(seed);
         Logger = loggerFactory.CreateLogger<MetaFactory>();
     }
 

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -7,8 +7,7 @@ namespace NuGettier.Upm;
 public interface IMetaFactory
 {
     string GenerateFolderMeta(string dirname);
-    string GenerateFileMeta(string seed, string filename);
-    string GenerateFileMeta(ulong seedHash, string filename);
+    string GenerateFileMeta(string filename);
 }
 
 public class MetaFactory : IMetaFactory

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -6,8 +6,7 @@ namespace NuGettier.Upm;
 
 public interface IMetaFactory
 {
-    string GenerateFolderMeta(string seed, string dirname);
-    string GenerateFolderMeta(ulong seedHash, string dirname);
+    string GenerateFolderMeta(string dirname);
     string GenerateFileMeta(string seed, string filename);
     string GenerateFileMeta(ulong seedHash, string filename);
 }

--- a/NuGettier.Upm/TarGz/FileDictionaryMetaExtension.cs
+++ b/NuGettier.Upm/TarGz/FileDictionaryMetaExtension.cs
@@ -6,7 +6,7 @@ namespace NuGettier.Upm.TarGz;
 
 public static class FileDictionaryMetaExtension
 {
-    public static void AddMetaFiles(this FileDictionary fileDictionary, string seed, IMetaFactory metaFactory)
+    public static void AddMetaFiles(this FileDictionary fileDictionary, IMetaFactory metaFactory)
     {
         var folderEntries = fileDictionary
             .Keys.Where(f => Path.GetExtension(f) != @".meta")
@@ -28,13 +28,13 @@ public static class FileDictionaryMetaExtension
         fileDictionary.AddRange(
             folderEntries
                 .OrderBy(f => f.Length)
-                .Select(f => new KeyValuePair<string, string>($"{f}.meta", metaFactory.GenerateFolderMeta(seed, f)))
+                .Select(f => new KeyValuePair<string, string>($"{f}.meta", metaFactory.GenerateFolderMeta(f)))
         );
         fileDictionary.AddRange(
             fileDictionary
                 .Keys.Where(f => Path.GetExtension(f) != @".meta")
                 .OrderBy(f => f.Length)
-                .Select(f => new KeyValuePair<string, string>($"{f}.meta", metaFactory.GenerateFileMeta(seed, f)))
+                .Select(f => new KeyValuePair<string, string>($"{f}.meta", metaFactory.GenerateFileMeta(f)))
         );
     }
 }


### PR DESCRIPTION
- refactor (NuGettier.Upm): reduce interface IMetaFactory.GenerateFolderMeta() to a single function
- refactor (NuGettier.Upm): reduce interface IMetaFactory.GenerateFileMeta() to a single function
- refactor (NuGettier.Upm): change MetaFactory.ctor() to take seed string
- refactor (NuGettier.Upm): adapt MetaFactory to implement simplified IMetaFactory interface
- refactor (NuGettier.Upm): adapt FileDictionary.AddMetaFiles() extension method to IMetaFactory methods not requiring seed
