### PR TITLE
refactor (NuGettier.Upm): replace xxHash computation library Standart.Hash.xxHash with System.IO.Hashing

### DIFF
--- a/NuGettier.Upm/MetaGen/Guid.cs
+++ b/NuGettier.Upm/MetaGen/Guid.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
-using Standart.Hash.xxHash;
+using System.IO.Hashing;
 
 namespace NuGettier.Upm.MetaGen;
 
 struct Guid
 {
-    public uint128 hash;
+    public UInt128 hash;
 
-    public static ulong SeedHash(string seed) => xxHash3.ComputeHash(seed);
+    public static UInt64 SeedHash(string seed) => XxHash3.HashToUInt64(Encoding.Default.GetBytes(seed));
 
     public Guid()
     {
@@ -21,11 +21,11 @@ struct Guid
 
     public Guid(ulong seedHash, string value)
     {
-        hash = xxHash128.ComputeHash(value, seedHash);
+        hash = XxHash128.HashToUInt128(Encoding.Default.GetBytes(value), (Int64)seedHash);
     }
 
     public override readonly string ToString()
     {
-        return $"{hash.high64:x8}{hash.low64:x8}";
+        return $"{hash:x}";
     }
 }

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -41,7 +41,6 @@
     <PackageReference Include="NuGet.Protocol" Version="6.8.0"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.0"/>
     <PackageReference Include="SharpZipLib" Version="1.4.2"/>
-    <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.IO.Hashing" Version="8.0.0"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
+    <PackageReference Include="System.IO.Hashing" Version="8.0.0"/>
     <PackageReference Include="System.Text.Json" Version="8.0.0"/>
     <PackageReference Include="Xunit" Version="2.6.4"/>
   </ItemGroup>


### PR DESCRIPTION
- build (NuGettier.Upm): add dependency on System.IO.Hashing v8.0.0
- build (NuGettier.Upm): remove dependency on Standart.Hash.xxHash
- refactor (NuGettier.Upm): replace xxHash computation library Standart.Hash.xxHash with System.IO.Hashing

rationale:
Guids, i.e. hashes generated with Standart.Hash.xxHash were getting rejected by Unity as
```
xxx.meta does not have a valid GUID and its corresponding Asset file will be ignored.
If this file is not malformed, please add a GUID, or delete the .meta file and it will be recreated correctly.

#0 GetStacktrace(int)
#1 DebugStringToFile(DebugStringToFileData const&)
#2 BuildReporting::LogRecordedErrorsToConsole(BuildReporting::BuildReport const&)
#3 Application::ParseARGVCommands()
#4 Application::FinishLoadingProject()
#5 NoGraphicsMain()
#6 EditorMain(int, char const**)
#7 main
#8 start
```