### PR TITLE
refactor (NuGettier.Upm): fix incorrect format of generated .npmrc in Upm.Context.GenerateNpmrc()

### DIFF
--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -61,16 +61,23 @@ public partial class Context
                 var uriScope = Target.Scope();
                 if (string.IsNullOrEmpty(uriScope))
                 {
-                    // `registry=${registry}/`
-                    await npmrcWriter.WriteLineAsync($"registry={Target.ScopelessAbsoluteUri()}");
+                    // `//registry=${registry}/`
+                    await npmrcWriter.WriteLineAsync($"//registry={Target.ScopelessAbsoluteUri()}/");
                 }
                 else
                 {
-                    // `${uriScope}:registry=${registry}/`
-                    await npmrcWriter.WriteLineAsync($"{uriScope}:registry={Target.ScopelessAbsoluteUri()}");
+                    // `//${uriScope}:registry=${registry}/`
+                    await npmrcWriter.WriteLineAsync($"//{uriScope}:registry={Target.ScopelessAbsoluteUri()}/");
                 }
-                // `//${schemeless_registry}/:_authToken=${token}`
-                await npmrcWriter.WriteLineAsync($"//{Target.SchemelessUri()}:_authToken={token}");
+
+                // `//${host}/:_authToken=${token}`
+                await npmrcWriter.WriteLineAsync($"//{Target.Host}/:_authToken={token}");
+
+                if (Target.Host != Target.Authority)
+                {
+                    // `//${host}:${port}/:_authToken=${token}`
+                    await npmrcWriter.WriteLineAsync($"//{Target.Authority}/:_authToken={token}");
+                }
             }
             targetNpmrc.Refresh();
         }

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -11,7 +11,7 @@ public static class UriExtension
     /// <returns>Uri.AbsoluteUri without the scheme nor the scope</returns>
     public static string SchemelessUri(this Uri uri)
     {
-        return uri.ScopelessAbsoluteUri().Replace($"{uri.Scheme}//", "").Replace("https://", "").Replace("http://", "");
+        return uri.ScopelessAbsoluteUri().Replace($"{uri.Scheme}://", "");
     }
 
     /// <summary>

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -11,7 +11,7 @@ public static class UriExtension
     /// <returns>Uri.AbsoluteUri without the scheme nor the scope</returns>
     public static string SchemelessUri(this Uri uri)
     {
-        return uri.ScopelessAbsoluteUri().Replace($"{uri.Scheme}://", "");
+        return uri.ScopelessAbsoluteUri().Replace($"{uri.Scheme}://", "").TrimEnd('/');
     }
 
     /// <summary>

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -23,9 +23,9 @@ public static class UriExtension
     {
         var scope = uri.Scope();
         if (string.IsNullOrEmpty(scope))
-            return uri.AbsoluteUri;
+            return uri.AbsoluteUri.TrimEnd('/');
 
-        return uri.AbsoluteUri.Replace(scope, "");
+        return uri.AbsoluteUri.Replace(scope, "").TrimEnd('/');
     }
 
     /// <summary>

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -33,11 +33,11 @@ public static class UriExtension
     /// https://my-awesome-server/npmapi/@scope -> @scope
     /// </summary>
     /// <returns>the scope</returns>
-    public static string? Scope(this Uri uri)
+    public static string Scope(this Uri uri)
     {
         var scopeIndex = uri.AbsolutePath.LastIndexOf(@"@");
         if (scopeIndex < 0)
-            return null;
+            return string.Empty;
 
         return uri.AbsolutePath.Substring(scopeIndex);
     }


### PR DESCRIPTION
- refactor (NuGettier.Upm): fix removing scheme in Uri.SchemelessUri() extension method
- refactor (NuGettier.Upm): trim potentially trailing '/' in  Uri.SchemelessUri() extension method
- refactor (NuGettier.Upm): trim potentially trailing '/' in  Uri.ScopelessAbsoluteUri() extension method
- refactor (NuGettier.Upm): change return type of Uri.Scope() extension method to not be null
- refactor (NuGettier.Upm): fix incorrect format of generated .npmrc in Upm.Context.GenerateNpmrc()
