### PR TITLE
refactor (NuGettier.Upm): pass registry URL with scope to 'npm publish --registry'

### DIFF
--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -84,7 +84,7 @@ public partial class Context
                 packageFile.Name,
                 string.IsNullOrEmpty(targetScope)
                     ? $"--registry={Target.ScopelessAbsoluteUri()}/"
-                    : $"--scope={targetScope}",
+                    : $"--registry={Target.AbsoluteUri}/",
                 dryRun ? "--dry-run" : string.Empty,
                 "--verbose",
                 $"--access={packageAccessLevel.ToString().ToLowerInvariant()}"


### PR DESCRIPTION
reason: this format works at least for publishing to GitHub NPM registry
