### PR TITLE
refactor (NuGettier.Upm): unify format used for registry Uri to work with and without @scope

### DIFF
--- a/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
+++ b/NuGettier.Upm/Context/PublishPackedUpmPackage.cs
@@ -82,9 +82,7 @@ public partial class Context
                 " ",
                 "publish",
                 packageFile.Name,
-                string.IsNullOrEmpty(targetScope)
-                    ? $"--registry={Target.ScopelessAbsoluteUri()}/"
-                    : $"--registry={Target.AbsoluteUri}/",
+                $"--registry={Target.ToNpmFormat()}",
                 dryRun ? "--dry-run" : string.Empty,
                 "--verbose",
                 $"--access={packageAccessLevel.ToString().ToLowerInvariant()}"

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -83,7 +83,7 @@ public partial class Context
 
         // add target
         packageJson.PublishingConfiguration ??= new PublishingConfiguration();
-        packageJson.PublishingConfiguration.Registry = $"{Target.ScopelessAbsoluteUri()}/";
+        packageJson.PublishingConfiguration.Registry = $"{Target.ToNpmFormat()}";
 
         // add repository/directory
         if (!string.IsNullOrEmpty(Repository))

--- a/NuGettier.Upm/StringFactories/NpmrcFactory.cs
+++ b/NuGettier.Upm/StringFactories/NpmrcFactory.cs
@@ -18,12 +18,12 @@ public class NpmrcFactory : INpmrcFactory, IDisposable
 
         var uriScope = registry.Scope();
         // `//registry=${registry}/`
-        builder.AppendLine($"//registry={registry.ScopelessAbsoluteUri()}/");
+        builder.AppendLine($"//registry={registry.ScopelessAbsoluteUri()}");
 
         if (!string.IsNullOrEmpty(uriScope))
         {
             // `//${uriScope}:registry=${registry}/`
-            builder.AppendLine($"//{uriScope}:registry={registry.ScopelessAbsoluteUri()}/");
+            builder.AppendLine($"//{uriScope}:registry={registry.ScopelessAbsoluteUri()}");
         }
 
         if (!string.IsNullOrEmpty(authToken))

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -41,9 +41,9 @@ public static class UriExtension
     {
         var scope = uri.Scope();
         if (string.IsNullOrEmpty(scope))
-            return uri.AbsoluteUri.TrimEnd('/');
+            return uri.AbsoluteUri.ToNpmFormat();
 
-        return uri.AbsoluteUri.Replace(scope, "").TrimEnd('/');
+        return uri.AbsoluteUri.Replace(scope, "").ToNpmFormat();
     }
 
     /// <summary>

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -29,7 +29,7 @@ public static class UriExtension
     /// <returns>Uri.AbsoluteUri without the scheme nor the scope</returns>
     public static string SchemelessUri(this Uri uri)
     {
-        return uri.ScopelessAbsoluteUri().Replace($"{uri.Scheme}://", "").TrimEnd('/');
+        return uri.ScopelessAbsoluteUri().Replace($"{uri.Scheme}://", "").ToNpmFormat();
     }
 
     /// <summary>

--- a/NuGettier.Upm/Utility/UriExtension.cs
+++ b/NuGettier.Upm/Utility/UriExtension.cs
@@ -5,6 +5,24 @@ namespace NuGettier.Upm;
 public static class UriExtension
 {
     /// <summary>
+    /// returns the Uri in the format required by `npm` with a single trailing '/'
+    /// https://my-awesome-server/npmapi/@scope -> https://my-awesome-server/npmapi/@scope/
+    /// https://my-awesome-server/npmapi/@scope/ -> https://my-awesome-server/npmapi/@scope/
+    /// https://my-awesome-server/npmapi -> https://my-awesome-server/npmapi/
+    /// https://my-awesome-server/npmapi/ -> https://my-awesome-server/npmapi/
+    /// </summary>
+    /// <returns>Uri as string with a single trailing slash</returns>
+    public static Uri ToNpmFormat(this Uri uri)
+    {
+        return new Uri(uri.AbsoluteUri.ToNpmFormat());
+    }
+
+    public static string ToNpmFormat(this string uri)
+    {
+        return $"{uri.TrimEnd('/')}/";
+    }
+
+    /// <summary>
     /// returns the schemeless Uri as required by `npm`
     /// https://my-awesome-server/npmapi/@scope -> my-awesome-server/npmapi
     /// </summary>


### PR DESCRIPTION
- feature (NuGettier.Upm): implement Uri.ToNpmFormat() extension method
- refactor (NuGettier.Upm): return Uri string in npm-compatible format from Uri.SchemelessUri() extension method
- refactor (NuGettier.Upm): return Uri string in npm-compatible format from Uri.ScopelessAbsoluteUri() extension method
- refactor (NuGettier.Upm): pass Uri in correct format (with @scope and trailing '/') to 'npm publish --registry'
- refactor (NuGettier.Upm): set package.json .publishConfig.registry Uri in correct format (with @scope and trailing '/') i.e. same as passed to 'npm publish --registry'
