### PR TITLE
fix ('build' action): build whole solution instead of single projects

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,4 +12,4 @@ runs:
     shell: pwsh
     run: |-
       echo "building Solution"
-      dotnet build -f ${{ inputs.framework }} -c ${{ inputs.configuration }}
+      dotnet build -f ${{ inputs.framework }} -c ${{ inputs.configuration }} -maxcpucount:1

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,8 +5,6 @@ inputs:
     default: Debug
   framework:
     required: true
-  exclude:
-    required: false
 runs:
   using: composite
   steps:

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -15,7 +15,7 @@ runs:
     run: |-
       $exclude = "${{ inputs.exclude }}"
       $excludeArg = [string]::IsNullOrEmpty($exclude) ? "" : "--exclude"
-      foreach ($project in @(fdfind $excludeArg $exclude "csproj$"))
+      foreach ($project in @(fdfind --search-path "." $excludeArg $exclude "csproj$"))
       {
         echo "building $project"
         dotnet build -f ${{ inputs.framework }} -c ${{ inputs.configuration }} $project

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -13,10 +13,5 @@ runs:
   - name: Build (${{ inputs.configuration }}) ${{ inputs.framework }}
     shell: pwsh
     run: |-
-      $exclude = "${{ inputs.exclude }}"
-      $excludeArg = [string]::IsNullOrEmpty($exclude) ? "" : "--exclude"
-      foreach ($project in @(fdfind --search-path "." $excludeArg $exclude "csproj$"))
-      {
-        echo "building $project"
-        dotnet build -f ${{ inputs.framework }} -c ${{ inputs.configuration }} $project
-      }
+      echo "building Solution"
+      dotnet build -f ${{ inputs.framework }} -c ${{ inputs.configuration }}

--- a/.github/jobactions/build/action.yml
+++ b/.github/jobactions/build/action.yml
@@ -5,8 +5,6 @@ inputs:
     default: Debug
   framework:
     required: true
-  exclude:
-    required: false
 runs:
   using: composite
   steps:
@@ -17,4 +15,3 @@ runs:
     with:
       framework: ${{ inputs.framework }}
       configuration: ${{ inputs.configuration }}
-      exclude: ${{ inputs.exclude }}


### PR DESCRIPTION
- fix ('build' action): pass explicit --search-path '.' to fdfind
- refactor ('build' action): build whole solution instead of single projects
  reason: easier, single call, avoid the 'exclude' issue
  caveat: whether a project should be build or not can be controlled from the solution file directly
- refactor ('build' action): remove parameter 'exclude'
   reason: not used anymore
- refactor ('build' jobaction): remove parameter 'exclude'
   reason: not used, not passed to underlying 'build' action
