### PR TITLE
refactor (NuGettier.Upm): use XXHash64 to compute seed hash

### DIFF
--- a/NuGettier.Upm/MetaGen/Guid.cs
+++ b/NuGettier.Upm/MetaGen/Guid.cs
@@ -9,7 +9,7 @@ struct Guid
 {
     public UInt128 hash;
 
-    public static UInt64 SeedHash(string seed) => XxHash3.HashToUInt64(Encoding.Default.GetBytes(seed));
+    public static UInt64 SeedHash(string seed) => XxHash64.HashToUInt64(Encoding.Default.GetBytes(seed));
 
     public Guid()
     {


### PR DESCRIPTION
reason: Unity complaining about generated GUIDs might be due to differences wrt hash generation.
result: Trying to stick as close as possible to metagen.js' implementation since that one works
        without issues.
