### PR TITLE
refactor (NuGettier.Upm): compute XXHash128 as digest from accumulating data to be hashed

### DIFF
--- a/NuGettier.Upm/MetaGen/Guid.cs
+++ b/NuGettier.Upm/MetaGen/Guid.cs
@@ -21,7 +21,9 @@ struct Guid
 
     public Guid(ulong seedHash, string value)
     {
-        hash = XxHash128.HashToUInt128(Encoding.Default.GetBytes(value), (Int64)seedHash);
+        XxHash128 xxHash = new((long)seedHash);
+        xxHash.Append(Encoding.Default.GetBytes(value));
+        hash = xxHash.GetCurrentHashAsUInt128();
     }
 
     public override readonly string ToString()


### PR DESCRIPTION
reason: Unity complaining about generated GUIDs might be due to differences wrt hash generation.
result: Trying to stick as close as possible to metagen.js' implementation since that one works
        without issues.
