### PR TITLE
build: update dependencies on NuGet to 6.9.1

### DIFF
--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="SharpZipLib" Version="1.4.2"/>

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="SharpZipLib" Version="1.4.2"/>
     <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5"/>

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
-    <PackageReference Include="NuGet.Commands" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>

--- a/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
+++ b/NuGettier.Amalgamate/NuGettier.Amalgamate.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.9.1"/>
     <PackageReference Include="SharpZipLib" Version="1.4.2"/>
     <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.9.1"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="Xunit" Version="2.6.4"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
-    <PackageReference Include="NuGet.Commands" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>

--- a/NuGettier.Core/NuGettier.Core.csproj
+++ b/NuGettier.Core/NuGettier.Core.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
-    <PackageReference Include="NuGet.Commands" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="SharpZipLib" Version="1.4.2"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.9.1"/>
     <PackageReference Include="SharpZipLib" Version="1.4.2"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>

--- a/NuGettier.Upm/NuGettier.Upm.csproj
+++ b/NuGettier.Upm/NuGettier.Upm.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="SharpZipLib" Version="1.4.2"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0"/>
-    <PackageReference Include="NuGet.Commands" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>

--- a/NuGettier/NuGettier.csproj
+++ b/NuGettier/NuGettier.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.9.1"/>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1"/>
     <PackageReference Include="System.Threading.Channels" Version="8.0.0"/>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="Xunit" Version="2.6.4"/>
     <PackageReference Include="ZLogger" Version="2.3.1"/>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Resolver" Version="6.9.1"/>
     <PackageReference Include="Xunit" Version="2.6.4"/>
     <PackageReference Include="ZLogger" Version="2.3.1"/>
   </ItemGroup>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
-    <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
+    <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
-    <PackageReference Include="NuGet.Commands" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.8.1"/>
     <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>

--- a/Prototype/Prototype.csproj
+++ b/Prototype/Prototype.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="NuGet.Commands" Version="6.9.1"/>
     <PackageReference Include="NuGet.LibraryModel" Version="6.9.1"/>
-    <PackageReference Include="NuGet.Packaging" Version="6.8.1"/>
+    <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
     <PackageReference Include="NuGet.Protocol" Version="6.8.1"/>
     <PackageReference Include="NuGet.Resolver" Version="6.8.1"/>
     <PackageReference Include="Xunit" Version="2.6.4"/>


### PR DESCRIPTION
- **build (Prototype): update dependency on NuGet.Commands to 6.9.1**
- **build (Prototype): update dependency on NuGet.LibraryModel to 6.9.1**
- **build (Prototype): update dependency on NuGet.Packaging to 6.9.1**
- **build (Prototype): update dependency on NuGet.Protocol to 6.9.1**
- **build (Prototype): update dependency on NuGet.Resolver to 6.9.1**
- **build (NuGettier): update dependency on NuGet.Commands to 6.9.1**
- **build (NuGettier): update dependency on NuGet.LibraryModel to 6.9.1**
- **build (NuGettier): update dependency on NuGet.Packaging to 6.9.1**
- **build (NuGettier): update dependency on NuGet.Protocol to 6.9.1**
- **build (NuGettier): update dependency on NuGet.Resolver to 6.9.1**
- **build (NuGettier.Core): update dependency on NuGet.Commands to 6.9.1**
- **build (NuGettier.Core): update dependency on NuGet.LibraryModel to 6.9.1**
- **build (NuGettier.Core): update dependency on NuGet.Packaging to 6.9.1**
- **build (NuGettier.Core): update dependency on NuGet.Protocol to 6.9.1**
- **build (NuGettier.Core): update dependency on NuGet.Resolver to 6.9.1**
- **build (NuGettier.Upm): update dependency on NuGet.Commands to 6.9.1**
- **build (NuGettier.Upm): update dependency on NuGet.LibraryModel to 6.9.1**
- **build (NuGettier.Upm): update dependency on NuGet.Packaging to 6.9.1**
- **build (NuGettier.Upm): update dependency on NuGet.Protocol to 6.9.1**
- **build (NuGettier.Upm): update dependency on NuGet.Resolver to 6.9.1**
- **build (NuGettier.Amalgamate): update dependency on NuGet.Commands to 6.9.1**
- **build (NuGettier.Amalgamate): update dependency on NuGet.LibraryModel to 6.9.1**
- **build (NuGettier.Amalgamate): update dependency on NuGet.Packaging to 6.9.1**
- **build (NuGettier.Amalgamate): update dependency on NuGet.Protocol to 6.9.1**
- **build (NuGettier.Amalgamate): update dependency on NuGet.Resolver to 6.9.1**
