### PR TITLE
refactor (NuGettier.Upm): split Guid.ToRfc4122Uuid() extension method into .ToRfc4122() and .ToUnityString() extension methods

### DIFF
--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -31,7 +31,7 @@ public class MetaFactory : IMetaFactory, IDisposable
             EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.folder.meta")
         );
         var metaContents = metaTemplate(new { guid = uuid });
-        Logger.LogDebug("generated meta file for folder {0} with (UUID: {1}):\n{2}", dirname, uuid, metaContents);
+        Logger.LogDebug("generated meta file for folder {0} with GUID: {1}:\n{2}", dirname, uuid, metaContents);
 
         return metaContents;
     }
@@ -47,7 +47,7 @@ public class MetaFactory : IMetaFactory, IDisposable
                 : EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.template.meta")
         );
         var metaContents = metaTemplate(new { guid = uuid });
-        Logger.LogDebug("generated meta file for file {0} with (UUID: {1}):\n{2}", filename, uuid, metaContents);
+        Logger.LogDebug("generated meta file for file {0} with GUID: {1}:\n{2}", filename, uuid, metaContents);
 
         return metaContents;
     }

--- a/NuGettier.Upm/StringFactories/MetaFactory.cs
+++ b/NuGettier.Upm/StringFactories/MetaFactory.cs
@@ -26,7 +26,7 @@ public class MetaFactory : IMetaFactory, IDisposable
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
 
-        var uuid = GuidFactory.GenerateGuid(dirname).ToRfc4122Uuid();
+        var uuid = GuidFactory.GenerateGuid(dirname).ToRfc4122().ToUnityString();
         var metaTemplate = Handlebars.Compile(
             EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.folder.meta")
         );
@@ -40,7 +40,7 @@ public class MetaFactory : IMetaFactory, IDisposable
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
 
-        var uuid = GuidFactory.GenerateGuid(filename).ToRfc4122Uuid();
+        var uuid = GuidFactory.GenerateGuid(filename).ToRfc4122().ToUnityString();
         var metaTemplate = Handlebars.Compile(
             Path.GetExtension(filename).EndsWith(".dll")
                 ? EmbeddedAssetHelper.GetEmbeddedResourceString("NuGettier.Upm.Templates.assembly.meta")

--- a/NuGettier.Upm/Utility/GuidExtension.cs
+++ b/NuGettier.Upm/Utility/GuidExtension.cs
@@ -4,12 +4,32 @@ namespace NuGettier.Upm;
 
 public static class GuidExtension
 {
-    public static string ToRfc4122Uuid(this Guid guid, byte version = 5)
+    /// <summary>
+    /// transforms the input Guid into a RFC-4122 UUID
+    /// </summary>
+    /// <see href="https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.6" />
+    /// <param name="guid">a Guid</param>
+    /// <param name="version">indicates the RFC-4122 'version' parameter, which is '5' for SHA1 UUIDs</param>
+    /// <returns>the same Guid with a few bits changed</returns>
+    /// <remarks>
+    /// discovered this in Xoofx' UnityNuGet source code
+    /// https://github.com/xoofx/UnityNuGet
+    /// </remarks>
+    public static Guid ToRfc4122(this Guid guid, byte version = 5)
     {
         byte[] bytes = guid.ToByteArray();
         bytes[6] = (byte)((bytes[6] & 0x0F) | (version << 4));
         bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
-        Guid uuid = new(bytes);
-        return uuid.ToString("N").ToLowerInvariant();
+        return new Guid(bytes);
+    }
+
+    /// <summary>
+    /// returns a Unity-compatible Guid string
+    /// </summary>
+    /// <param name="guid">a Guid</param>
+    /// <returns>lowercase hexadecimal character string without separators</returns>
+    public static string ToUnityString(this Guid guid)
+    {
+        return guid.ToString("N").ToLowerInvariant();
     }
 }


### PR DESCRIPTION
- **refactor (NuGettier.Upm): split Guid.ToRfc4122Uuid() extension method into .ToRfc4122() and .ToUnityString() extension methods**
  reason: improve code understanding
  

- **refactor (NuGettier.Upm): improve debug logs in MetaFactory**
  