### PR TITLE
fix (NuGettier et al): obtain scoped services as interfaces instead of implementations

### DIFF
--- a/NuGettier.Upm/Context/GenerateNpmrc.cs
+++ b/NuGettier.Upm/Context/GenerateNpmrc.cs
@@ -61,7 +61,7 @@ public partial class Context
 
             using (var serviceScope = Host.Services.CreateScope())
             {
-                NpmrcFactory npmrcFactory = serviceScope.ServiceProvider.GetRequiredService<NpmrcFactory>();
+                INpmrcFactory npmrcFactory = serviceScope.ServiceProvider.GetRequiredService<INpmrcFactory>();
                 await File.WriteAllTextAsync(targetNpmrc.FullName, npmrcFactory.GenerateNpmrc(Target, token));
             }
             targetNpmrc.Refresh();

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -122,7 +122,7 @@ public partial class Context
         // add meta files
         using (var serviceScope = Host.Services.CreateScope())
         {
-            MetaFactory metaFactory = serviceScope.ServiceProvider.GetRequiredService<MetaFactory>();
+            IMetaFactory metaFactory = serviceScope.ServiceProvider.GetRequiredService<IMetaFactory>();
             metaFactory.InitializeWithSeed(seed: packageJson.Name);
             files.AddMetaFiles(metaFactory: metaFactory);
         }

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -99,7 +99,8 @@ public partial class Context
         {
             using (var serviceScope = Host.Services.CreateScope())
             {
-                ChangelogFactory changelogFactory = serviceScope.ServiceProvider.GetRequiredService<ChangelogFactory>();
+                IChangelogFactory changelogFactory =
+                    serviceScope.ServiceProvider.GetRequiredService<IChangelogFactory>();
                 var changelog = packageJson.GenerateChangelog(
                     releaseNotes: packageReader.NuspecReader.GetReleaseNotes(),
                     changelogFactory: changelogFactory

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -82,7 +82,7 @@ public partial class Context
         {
             using (var serviceScope = Host.Services.CreateScope())
             {
-                LicenseFactory licenseFactory = serviceScope.ServiceProvider.GetRequiredService<LicenseFactory>();
+                ILicenseFactory licenseFactory = serviceScope.ServiceProvider.GetRequiredService<ILicenseFactory>();
                 var license = packageJson.GenerateLicense(
                     originalLicense: packageReader.GetLicense(),
                     copyright: packageReader.NuspecReader.GetCopyright(),

--- a/NuGettier.Upm/Context/PackUpmPackage.cs
+++ b/NuGettier.Upm/Context/PackUpmPackage.cs
@@ -67,7 +67,7 @@ public partial class Context
         {
             using (var serviceScope = Host.Services.CreateScope())
             {
-                ReadmeFactory readmeFactory = serviceScope.ServiceProvider.GetRequiredService<ReadmeFactory>();
+                IReadmeFactory readmeFactory = serviceScope.ServiceProvider.GetRequiredService<IReadmeFactory>();
                 var readme = packageJson.GenerateReadme(
                     originalReadme: packageReader.GetReadme(),
                     readmeFactory: readmeFactory

--- a/NuGettier/UpmActions/UpmMetagen.cs
+++ b/NuGettier/UpmActions/UpmMetagen.cs
@@ -44,7 +44,7 @@ public partial class NuGettierService
         Logger.LogTrace("force: {0}", force);
 
         var serviceScope = Host.Services.CreateScope();
-        MetaFactory metaFactory = serviceScope.ServiceProvider.GetRequiredService<MetaFactory>();
+        IMetaFactory metaFactory = serviceScope.ServiceProvider.GetRequiredService<IMetaFactory>();
         metaFactory.InitializeWithSeed(seed);
         Matcher matcher = new();
         matcher.AddExclude(@"*.meta");


### PR DESCRIPTION
- **fix (NuGettier.Upm): obtain interface INpmrcFactory instead of implementation in Upm.Context.GenerateNpmrc()**
  this fixes a runtime crash
  

- **fix (NuGettier.Upm): obtain interface IReadmeFactory instead of implementation in Upm.Context.PackUpmPackage()**
  this fixes a runtime crash
  

- **fix (NuGettier.Upm): obtain interface ILicenseFactory instead of implementation in Upm.Context.PackUpmPackage()**
  this fixes a runtime crash
  

- **fix (NuGettier.Upm): obtain interface IChangelogFactory instead of implementation in Upm.Context.PackUpmPackage()**
  this fixes a runtime crash
  

- **fix (NuGettier.Upm): obtain interface IMetaFactory instead of implementation in Upm.Context.PackUpmPackage()**
  this fixes a runtime crash
  

- **fix (NuGettier): obtain interface IMetaFactory instead of implementation in UpmMetagen command**
  this fixes a runtime crash
  