### PR TITLE
refactor (NuGettier): change order of configuration providers

### DIFF
--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -45,8 +45,8 @@ public static class Program
                             optional: true,
                             reloadOnChange: false
                         )
-                        .AddEnvironmentVariables("NUGETTIER_")
-                        .AddDotNetConfig();
+                        .AddDotNetConfig()
+                        .AddEnvironmentVariables("NUGETTIER_");
                 }
             )
             .ConfigureLogging(


### PR DESCRIPTION
in order to prioritize environment variables over configuration files.

reason: .netconfig had higher priority than environment variables,
        which resulted in settings not being overridable.
