### PR TITLE
fix (NuGettier): set correct path to system-level appconfig.json

### DIFF
--- a/NuGettier/Program.cs
+++ b/NuGettier/Program.cs
@@ -5,6 +5,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.NamingConventionBinder;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetConfig;
@@ -39,7 +40,14 @@ public static class Program
                 (context, builder) =>
                 {
                     builder
-                        .AddJsonFile("appconfig.json", optional: false, reloadOnChange: false)
+                        .AddJsonFile(
+                            Path.Join(
+                                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                                "appconfig.json"
+                            ),
+                            optional: false,
+                            reloadOnChange: false
+                        )
                         .AddJsonFile(
                             Path.Join(Environment.CurrentDirectory, "appconfig.json"),
                             optional: true,


### PR DESCRIPTION
namely in the same folder as the executing assembly

explanation: Host.CreateDefaultBuilder() creates an IHostBuilder
             and sets a number defaults, as well as the
             the application base path to the current directory.
             This last point forces the system-level appconfig.json as well,
             to be present in the current directory.
             This goes agains the initial, and intended, application configuration,
             which meant to look for the system-level appconfig.json next to its
             executing assembly.
