### PR TITLE
refactor (NuGettier.Upm): register and select GuidFactories via reflection using attribute for build-time-constant identifier

### DIFF
--- a/NuGettier.Upm/Guid/GuidIdentifierAttribute.cs
+++ b/NuGettier.Upm/Guid/GuidIdentifierAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace NuGettier.Upm;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class GuidIdentifierAttribute([Required(AllowEmptyStrings = false)] string identifier) : Attribute()
+{
+    [Required(AllowEmptyStrings = false)]
+    public string Identifier { get; set; } = identifier;
+}

--- a/NuGettier.Upm/HostBuilder/ConfigureStringFactories.cs
+++ b/NuGettier.Upm/HostBuilder/ConfigureStringFactories.cs
@@ -19,14 +19,22 @@ public static class ConfigureStringFactoriesExtensions
                 services.AddScoped<IChangelogFactory, ChangelogFactory>();
                 services.AddScoped<IMetaFactory, MetaFactory>();
                 services.AddScoped<IGuidFactory, GuidFactoryProxy>();
-                services.AddKeyedScoped<IGuidFactory, Sha1GuidFactory>("sha1");
-                services.AddKeyedScoped<IGuidFactory, Md5GuidFactory>("md5");
-                services.AddKeyedScoped<IGuidFactory, XxHash128GuidFactory>("xxhash128");
-                services.AddKeyedScoped<IGuidFactory, XxHash3GuidFactory>("xxhash3");
-                services.AddKeyedScoped<IGuidFactory, XxHash64GuidFactory>("xxhash64");
-                services.AddKeyedScoped<IGuidFactory, Upm.Uranium.XxHash128GuidFactory>("uranium.xxhash128");
-                services.AddKeyedScoped<IGuidFactory, Upm.Uranium.XxHash3GuidFactory>("uranium.xxhash3");
-                services.AddKeyedScoped<IGuidFactory, Upm.Uranium.XxHash64GuidFactory>("uranium.xxhash64");
+
+                Type interfaceType = typeof(IGuidFactory);
+                foreach (
+                    Type type in Assembly
+                        .GetExecutingAssembly()
+                        .GetTypes()
+                        .Where(t => t.GetInterfaces().Contains(interfaceType))
+                )
+                {
+                    var attribute = type.GetCustomAttribute<GuidIdentifierAttribute>();
+                    if (attribute is not null)
+                    {
+                        services.AddKeyedScoped(interfaceType, attribute.Identifier, type);
+                    }
+                }
+
                 services.AddOptions<GuidFactorySettings>().Bind(context.Configuration.GetSection("guid"));
             }
         );

--- a/NuGettier.Upm/StringFactories/GuidFactoryProxy.cs
+++ b/NuGettier.Upm/StringFactories/GuidFactoryProxy.cs
@@ -9,6 +9,8 @@ namespace NuGettier.Upm;
 
 public class GuidFactoryProxy : IGuidFactory, IDisposable
 {
+    const string kDefaultIdentifier = "sha1";
+
     protected readonly ILogger Logger;
     protected readonly IGuidFactory GuidFactory;
 
@@ -20,11 +22,11 @@ public class GuidFactoryProxy : IGuidFactory, IDisposable
     {
         Logger = logger;
 
-        var algorithm = !string.IsNullOrEmpty(options?.Value.Algorithm) ? options!.Value.Algorithm : "sha1";
-        logger.LogTrace("algorithm: {0}", algorithm);
+        var identifier = !string.IsNullOrEmpty(options?.Value.Algorithm) ? options!.Value.Algorithm : kDefaultIdentifier;
+        logger.LogTrace("identifier: {0}", identifier);
         GuidFactory =
-            serviceProvider.GetKeyedService<IGuidFactory>(algorithm)
-            ?? serviceProvider.GetRequiredKeyedService<IGuidFactory>("sha1");
+            serviceProvider.GetKeyedService<IGuidFactory>(identifier)
+            ?? serviceProvider.GetRequiredKeyedService<IGuidFactory>(kDefaultIdentifier);
     }
 
     public virtual void Dispose() { }

--- a/NuGettier.Upm/StringFactories/Md5GuidFactory.cs
+++ b/NuGettier.Upm/StringFactories/Md5GuidFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace NuGettier.Upm;
 
+[GuidIdentifier("md5")]
 public class Md5GuidFactory : IGuidFactory, IDisposable
 {
     protected readonly ILogger Logger;

--- a/NuGettier.Upm/StringFactories/Sha1GuidFactory.cs
+++ b/NuGettier.Upm/StringFactories/Sha1GuidFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace NuGettier.Upm;
 
+[GuidIdentifier("sha1")]
 public class Sha1GuidFactory : IGuidFactory, IDisposable
 {
     protected readonly ILogger Logger;

--- a/NuGettier.Upm/StringFactories/Uranium.XxHash128GuidFactory.cs
+++ b/NuGettier.Upm/StringFactories/Uranium.XxHash128GuidFactory.cs
@@ -5,6 +5,7 @@ using Standart.Hash.xxHash;
 
 namespace NuGettier.Upm.Uranium;
 
+[GuidIdentifier("uranium.xxhash128")]
 public class XxHash128GuidFactory : IGuidFactory, IDisposable
 {
     protected readonly ILogger Logger;

--- a/NuGettier.Upm/StringFactories/Uranium.XxHash3GuidFactory.cs
+++ b/NuGettier.Upm/StringFactories/Uranium.XxHash3GuidFactory.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace NuGettier.Upm.Uranium;
 
+[GuidIdentifier("uranium.xxhash3")]
 public class XxHash3GuidFactory : IGuidFactory, IDisposable
 {
     protected readonly ILogger Logger;

--- a/NuGettier.Upm/StringFactories/Uranium.XxHash64GuidFactory.cs
+++ b/NuGettier.Upm/StringFactories/Uranium.XxHash64GuidFactory.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace NuGettier.Upm.Uranium;
 
+[GuidIdentifier("uranium.xxhash64")]
 public class XxHash64GuidFactory : IGuidFactory, IDisposable
 {
     protected readonly ILogger Logger;

--- a/NuGettier.Upm/StringFactories/XxHash128GuidFactory.cs
+++ b/NuGettier.Upm/StringFactories/XxHash128GuidFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace NuGettier.Upm;
 
+[GuidIdentifier("xxhash128")]
 public class XxHash128GuidFactory : IGuidFactory, IDisposable
 {
     protected readonly ILogger Logger;

--- a/NuGettier.Upm/StringFactories/XxHash3GuidFactory.cs
+++ b/NuGettier.Upm/StringFactories/XxHash3GuidFactory.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace NuGettier.Upm;
 
+[GuidIdentifier("xxhash3")]
 public class XxHash3GuidFactory : IGuidFactory, IDisposable
 {
     protected readonly ILogger Logger;

--- a/NuGettier.Upm/StringFactories/XxHash64GuidFactory.cs
+++ b/NuGettier.Upm/StringFactories/XxHash64GuidFactory.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace NuGettier.Upm;
 
+[GuidIdentifier("xxhash64")]
 public class XxHash64GuidFactory : IGuidFactory, IDisposable
 {
     protected readonly ILogger Logger;


### PR DESCRIPTION
- **feature (NuGettier.Upm): implement [GuidIdentifier] attribute**
- **feature (NuGettier.Upm): add [GuidIdentifier] attribute to Sha1GuidFactory**
- **feature (NuGettier.Upm): add [GuidIdentifier] attribute to Md5GuidFactory**
- **feature (NuGettier.Upm): add [GuidIdentifier] attribute to XxHash128GuidFactory**
- **feature (NuGettier.Upm): add [GuidIdentifier] attribute to XxHash3GuidFactory**
- **feature (NuGettier.Upm): add [GuidIdentifier] attribute to XxHash64GuidFactory**
- **feature (NuGettier.Upm): add [GuidIdentifier] attribute to Uranium.XxHash128GuidFactory**
- **feature (NuGettier.Upm): add [GuidIdentifier] attribute to Uranium.XxHash3GuidFactory**
- **feature (NuGettier.Upm): add [GuidIdentifier] attribute to Uranium.XxHash64GuidFactory**
- **refactor (NuGettier.Upm): register GuidFactories having a [GuidIdentifier] attribute automatically via reflection**
- **refactor (NuGettier.Upm): reduce string repetition in GuidFactoryProxy.ctor()**
- **refactor (NuGettier.Upm): select default GuidFactory identifier via reflection**
