### PR TITLE
feature (NuGettier.Upm): extend GuidFactoryProxy with configurable/injectable GuidFormatter

### DIFF
--- a/NuGettier.Upm/Guid/GuidFormatterTypeAttribute.cs
+++ b/NuGettier.Upm/Guid/GuidFormatterTypeAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace NuGettier.Upm;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class GuidFormatterTypeAttribute(GuidFormat format) : Attribute()
+{
+    public GuidFormat Format { get; set; } = format;
+}

--- a/NuGettier.Upm/Guid/IGuidFormatter.cs
+++ b/NuGettier.Upm/Guid/IGuidFormatter.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace NuGettier.Upm;
+
+public interface IGuidFormatter
+{
+    Guid Apply(Guid guid);
+}

--- a/NuGettier.Upm/Guid/NullGuidFormatter.cs
+++ b/NuGettier.Upm/Guid/NullGuidFormatter.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace NuGettier.Upm;
+
+public class NullGuidFormatter : IGuidFormatter
+{
+    public virtual Guid Apply(Guid guid) => guid;
+}

--- a/NuGettier.Upm/Guid/NullGuidFormatter.cs
+++ b/NuGettier.Upm/Guid/NullGuidFormatter.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace NuGettier.Upm;
 
+[GuidFormatterType(GuidFormat.None)]
 public class NullGuidFormatter : IGuidFormatter
 {
     public virtual Guid Apply(Guid guid) => guid;

--- a/NuGettier.Upm/Guid/Rfc4122GuidFormatter.cs
+++ b/NuGettier.Upm/Guid/Rfc4122GuidFormatter.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace NuGettier.Upm;
+
+public class Rfc4122GuidFormatter : IGuidFormatter
+{
+    public virtual Guid Apply(Guid guid) => guid.ToRfc4122();
+}

--- a/NuGettier.Upm/Guid/Rfc4122GuidFormatter.cs
+++ b/NuGettier.Upm/Guid/Rfc4122GuidFormatter.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace NuGettier.Upm;
 
+[GuidFormatterType(GuidFormat.Rfc4122)]
 public class Rfc4122GuidFormatter : IGuidFormatter
 {
     public virtual Guid Apply(Guid guid) => guid.ToRfc4122();

--- a/NuGettier.Upm/Guid/UnityGuidFormatter.cs
+++ b/NuGettier.Upm/Guid/UnityGuidFormatter.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace NuGettier.Upm;
 
+[GuidFormatterType(GuidFormat.Unity)]
 public class UnityGuidFormatter : IGuidFormatter
 {
     public virtual Guid Apply(Guid guid) => guid.ToUnityGUID();

--- a/NuGettier.Upm/Guid/UnityGuidFormatter.cs
+++ b/NuGettier.Upm/Guid/UnityGuidFormatter.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace NuGettier.Upm;
+
+public class UnityGuidFormatter : IGuidFormatter
+{
+    public virtual Guid Apply(Guid guid) => guid.ToUnityGUID();
+}

--- a/NuGettier.Upm/Guid/UnityRfc4122GuidFormatter.cs
+++ b/NuGettier.Upm/Guid/UnityRfc4122GuidFormatter.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace NuGettier.Upm;
 
+[GuidFormatterType(GuidFormat.Unity_Rfc4122)]
 public class UnityRfc4122GuidFormatter : IGuidFormatter
 {
     public virtual Guid Apply(Guid guid) => guid.ToUnityGUID().ToRfc4122();

--- a/NuGettier.Upm/Guid/UnityRfc4122GuidFormatter.cs
+++ b/NuGettier.Upm/Guid/UnityRfc4122GuidFormatter.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace NuGettier.Upm;
+
+public class UnityRfc4122GuidFormatter : IGuidFormatter
+{
+    public virtual Guid Apply(Guid guid) => guid.ToUnityGUID().ToRfc4122();
+}

--- a/NuGettier.Upm/HostBuilder/ConfigureStringFactories.cs
+++ b/NuGettier.Upm/HostBuilder/ConfigureStringFactories.cs
@@ -20,18 +20,33 @@ public static class ConfigureStringFactoriesExtensions
                 services.AddScoped<IMetaFactory, MetaFactory>();
                 services.AddScoped<IGuidFactory, GuidFactoryProxy>();
 
-                Type interfaceType = typeof(IGuidFactory);
+                Type iGuidFactoryType = typeof(IGuidFactory);
                 foreach (
                     Type type in Assembly
                         .GetExecutingAssembly()
                         .GetTypes()
-                        .Where(t => t.GetInterfaces().Contains(interfaceType))
+                        .Where(t => t.GetInterfaces().Contains(iGuidFactoryType))
                 )
                 {
                     var attribute = type.GetCustomAttribute<GuidIdentifierAttribute>();
                     if (attribute is not null)
                     {
-                        services.AddKeyedScoped(interfaceType, attribute.Identifier, type);
+                        services.AddKeyedScoped(iGuidFactoryType, attribute.Identifier, type);
+                    }
+                }
+
+                Type iGuidFormatterType = typeof(IGuidFormatter);
+                foreach (
+                    Type type in Assembly
+                        .GetExecutingAssembly()
+                        .GetTypes()
+                        .Where(t => t.GetInterfaces().Contains(iGuidFormatterType))
+                )
+                {
+                    var attribute = type.GetCustomAttribute<GuidFormatterTypeAttribute>();
+                    if (attribute is not null)
+                    {
+                        services.AddKeyedScoped(iGuidFormatterType, attribute.Format, type);
                     }
                 }
 

--- a/NuGettier.Upm/Settings/GuidFactorySettings.cs
+++ b/NuGettier.Upm/Settings/GuidFactorySettings.cs
@@ -15,4 +15,5 @@ public enum GuidFormat
 public sealed class GuidFactorySettings
 {
     public string Algorithm { get; set; } = string.Empty;
+    public GuidFormat Format { get; set; } = GuidFormat.None;
 }

--- a/NuGettier.Upm/Settings/GuidFactorySettings.cs
+++ b/NuGettier.Upm/Settings/GuidFactorySettings.cs
@@ -2,6 +2,16 @@ using System;
 
 namespace NuGettier.Upm;
 
+[Flags]
+public enum GuidFormat
+{
+    None = 0,
+    Unity = 1,
+    Rfc4122 = 2,
+    Unity_Rfc4122 = Unity | Rfc4122,
+    Mask = Unity | Rfc4122,
+}
+
 public sealed class GuidFactorySettings
 {
     public string Algorithm { get; set; } = string.Empty;

--- a/NuGettier.Upm/StringFactories/GuidFactoryProxy.cs
+++ b/NuGettier.Upm/StringFactories/GuidFactoryProxy.cs
@@ -14,6 +14,7 @@ public class GuidFactoryProxy : IGuidFactory, IDisposable
 
     protected readonly ILogger Logger;
     protected readonly IGuidFactory GuidFactory;
+    protected readonly IGuidFormatter GuidFormatter;
 
     public GuidFactoryProxy(
         ILogger<GuidFactoryProxy> logger,
@@ -36,11 +37,16 @@ public class GuidFactoryProxy : IGuidFactory, IDisposable
         GuidFactory =
             serviceProvider.GetKeyedService<IGuidFactory>(identifier)
             ?? serviceProvider.GetRequiredKeyedService<IGuidFactory>(kDefaultIdentifier);
+
+        logger.LogTrace("using Guid formatter: {0}", options?.Value.Format ?? GuidFormat.None);
+        GuidFormatter =
+            serviceProvider.GetKeyedService<IGuidFormatter>(options?.Value.Format ?? GuidFormat.None)
+            ?? serviceProvider.GetRequiredKeyedService<IGuidFormatter>(GuidFormat.None);
     }
 
     public virtual void Dispose() { }
 
     public virtual void InitializeWithSeed(string seed) => GuidFactory.InitializeWithSeed(seed);
 
-    public virtual Guid GenerateGuid(string value) => GuidFactory.GenerateGuid(value);
+    public virtual Guid GenerateGuid(string value) => GuidFormatter.Apply(GuidFactory.GenerateGuid(value));
 }


### PR DESCRIPTION
- **feature (NuGettier.Upm): define enum GuidFormat**
- **feature (NuGettier.Upm): add GuidFormat to GuidFactorySettings**
- **feature (NuGettier.Upm): define interface IGuidFormatter**
- **feature (NuGettier.Upm): implement interface IGuidModifier for Unity format as UnityGuidFormatter**
- **feature (NuGettier.Upm): implement interface IGuidModifier for RFC-4122 format as Rfc4122GuidFormatter**
- **feature (NuGettier.Upm): implement interface IGuidModifier for combined Unity and RFC-4122 format as UnityRfc4122GuidFormatter**
- **feature (NuGettier.Upm): implement interface IGuidModifier passthrough as NullGuidFormatter**
- **feature (NuGettier.Upm): implement [GuidFormatterType] attribute**
- **feature (NuGettier.Upm): add [GuidFormatterType] attribute to NullGuidFormatter**
- **feature (NuGettier.Upm): add [GuidFormatterType] attribute to UnityGuidFormatter**
- **feature (NuGettier.Upm): add [GuidFormatterType] attribute to Rfc4122GuidFormatter**
- **feature (NuGettier.Upm): add [GuidFormatterType] attribute to UnityRfc4122GuidFormatter**
- **feature (NuGettier.Upm): register GuidFormatter having attribute [GuidFormatterType] automatically via reflection**
- **feature (NuGettier.Upm): dependency inject IGuidFormatter into GuidFactoryProxy, depending on GuidFactorySettings.Format**
