### PR TITLE
refactor ('tag' jobaction): fix potential integer overflow in projects AssemblyVersion

### DIFF
--- a/.github/jobactions/tag/action.yml
+++ b/.github/jobactions/tag/action.yml
@@ -43,9 +43,10 @@ runs:
 
       foreach ($project in @(fdfind "csproj$"))
       {
-        $revision = "$(git rev-list --all --count -- $project)"
-        $assemblyVersion = "$version.${{ github.run_number }}"
-        $fileVersion = "$version.$revision"
+        $assemblyRevision = "$(git rev-list --all --count -- $(Split-Path -Parent $project))"
+        $fileRevision = "$(git rev-list --all --count -- $project)"
+        $assemblyVersion = "$version.$assemblyRevision"
+        $fileVersion = "$version.$fileRevision"
         echo "patching $project"
         echo "assembly version: $assemblyVersion"
         echo "file version: $fileVersion"


### PR DESCRIPTION
explainer: version elements are stored by MSBuild et al. as unsigned 16-bit integers, thus values cannot exceed 65536
