### PR TITLE
refactor (NuGettier.Upm): simplify chained package searches and add case-unsensitive regex-match in Upm.Context.GetPackageRule()

### DIFF
--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -33,6 +33,9 @@ public partial class Context
             ?? packageRulesByLengthDescending
                 .Where(r => Regex.IsMatch(r.Id, packageId))
                 .FirstOrDefault()
+            ?? packageRulesByLengthDescending
+                .Where(r => Regex.IsMatch(r.Id, packageId, RegexOptions.IgnoreCase))
+                .FirstOrDefault()
             ?? defaultRule;
 
         // create and return new package rule if retrieved one does not contain important information

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -26,11 +26,14 @@ public partial class Context
         var packageRulesByLengthDescending = PackageRules.OrderByDescending(r => r.Id.Length);
 
         // search for equality first, then regex to have e.g. a specific rule for "System.Text.Json" and a generic rule for "System.Text.*" that don't overlap
-        var packageRule = packageRulesByLengthDescending
-            .Where(r => r.Id == packageId)
-            .FirstOrDefault(
-                packageRulesByLengthDescending.Where(r => Regex.IsMatch(r.Id, packageId)).FirstOrDefault(defaultRule)
-            );
+        var packageRule =
+            packageRulesByLengthDescending
+                .Where(r => r.Id == packageId)
+                .FirstOrDefault()
+            ?? packageRulesByLengthDescending
+                .Where(r => Regex.IsMatch(r.Id, packageId))
+                .FirstOrDefault()
+            ?? defaultRule;
 
         // create and return new package rule if retrieved one does not contain important information
         if (


### PR DESCRIPTION
- **refactor (NuGettier.Upm): simplify chained package searches in Upm.Context.GetPackageRule()**
  detail: instead of chaining sub-searches into LINQ .FirstOrDefault, we let the latter return default (null)
          and append the next search with ??
  

- **refactor (NuGettier.Upm): add case-unsensitive regex match to package searches in Upm.Context.GetPackageRule()**
  