### PR TITLE
refactor (NuGettier.Upm): assert retrieved package rule is not-null before accessing it

### DIFF
--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -134,6 +134,8 @@ public partial class Context
 
         Logger.LogTrace($"before: {packageId}: {packageVersion}");
         var packageRule = GetPackageRule(packageId);
+        Assert.NotNull(packageRule);
+
         var versionRegex = !string.IsNullOrEmpty(packageRule.Version)
             ? packageRule.Version
             : Context.DefaultPackageRule.Version;

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -37,6 +37,7 @@ public partial class Context
                 .Where(r => Regex.IsMatch(r.Id, packageId, RegexOptions.IgnoreCase))
                 .FirstOrDefault()
             ?? defaultRule;
+        Assert.NotNull(packageRule);
 
         // create and return new package rule if retrieved one does not contain important information
         if (

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -19,7 +19,7 @@ public partial class Context
     public PackageRule GetPackageRule(string packageId)
     {
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
-        var defaultRule = PackageRules.Where(r => string.IsNullOrEmpty(r.Id)).FirstOrDefault(DefaultPackageRule);
+        var defaultRule = PackageRules.Where(r => string.IsNullOrEmpty(r.Id)).FirstOrDefault() ?? DefaultPackageRule;
 
         // descending order used for regex match, so that `.*` will match last
         // rationale: this allows to have generic rules for e.g. "Microsoft.Extensions.Logging.*" and "Microsoft.Extensions.*" that don't overlap

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -111,6 +111,8 @@ public partial class Context
         Assert.NotNull(metadata);
 
         var packageRule = GetPackageRule(packageId);
+        Assert.NotNull(packageRule);
+
         string namingTemplate = !string.IsNullOrEmpty(packageRule.Name)
             ? packageRule.Name
             : Context.DefaultPackageRule.Name;

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -70,6 +70,7 @@ public partial class Context
 
         // get packageRule for this package
         var packageRule = GetPackageRule(packageJson.Name);
+        Assert.NotNull(packageRule);
 
         // patch packageJson.Name, .Version and .MinUnityVersion
         packageJson.Name = PatchPackageId(packageId: packageJson.Name);


### PR DESCRIPTION
- **refactor (NuGettier.Upm): assign first empty package rule or system-wide default to default rule in Upm.Context.GetPackageRule()**
- **refactor (NuGettier.Upm): assert that retrieved package rule is not null in Upm.Context.GetPackageRule()**
- **refactor (NuGettier.Upm): assert that retrieved package rule is not null in Upm.Context.PatchPackageJson()**
- **refactor (NuGettier.Upm): assert that retrieved package rule is not null in Upm.Context.PatchPackageId()**
- **refactor (NuGettier.Upm): assert that retrieved package rule is not null in Upm.Context.PatchPackageVersion()**
