### PR TITLE
refactor (NuGettier.Upm): fix read/write access on CachedMetadata

### DIFF
--- a/NuGettier.Upm/Context/GetPackageInformation.cs
+++ b/NuGettier.Upm/Context/GetPackageInformation.cs
@@ -39,7 +39,8 @@ public partial class Context
         );
         if (packageSearchMetadata != null)
         {
-            CachedMetadata[packageId.ToLowerInvariant()] = packageSearchMetadata;
+            if (!CachedMetadata.ContainsKey(packageId.ToLowerInvariant()))
+                CachedMetadata[packageId.ToLowerInvariant()] = packageSearchMetadata;
 
             var packageDependencyGroup = NuGetFrameworkUtility.GetNearest<PackageDependencyGroup>(
                 packageSearchMetadata.DependencySets,
@@ -65,7 +66,11 @@ public partial class Context
                 foreach (var metadata in dependencyPackageSearchMetadata)
                 {
                     if (metadata != null)
-                        CachedMetadata[metadata.Identity.Id.ToLowerInvariant()] = metadata;
+                    {
+                        var metadataId = metadata.Identity.Id.ToLowerInvariant();
+                        if (!CachedMetadata.ContainsKey(metadataId))
+                            CachedMetadata[metadataId] = metadata;
+                    }
                 }
             }
         }

--- a/NuGettier.Upm/Context/Utility.cs
+++ b/NuGettier.Upm/Context/Utility.cs
@@ -107,7 +107,7 @@ public partial class Context
         using var scope = Logger.TraceLocation().BeginScope(this.__METHOD__());
 
         Logger.LogTrace($"before: {packageId}");
-        var metadata = CachedMetadata[packageId.ToLowerInvariant()];
+        CachedMetadata.TryGetValue(packageId.ToLowerInvariant(), out var metadata);
         Assert.NotNull(metadata);
 
         var packageRule = GetPackageRule(packageId);


### PR DESCRIPTION
- **refactor (NuGettier.Upm): do not overwrite CachedMetadata when key already exists in Upm.Context.GetPackageInformation()**
- **refactor (NuGettier.Upm): fix read access on CachedMetadata to not crash for non-existing key in Upm.Context.PatchPackageId()**
