### PR TITLE
fix (NuGettier.Upm): set JsonPropertyName for PackageJson.PublishingConfiguration to `publishConfig`

### DIFF
--- a/NuGettier.Upm/PackageJson/PackageJson.cs
+++ b/NuGettier.Upm/PackageJson/PackageJson.cs
@@ -52,7 +52,7 @@ public partial record class PackageJson
     [JsonPropertyName("repository")]
     public Repository Repository { get; set; } = new Repository();
 
-    [JsonPropertyName("publishingConfiguration")]
+    [JsonPropertyName("publishConfig")]
     public PublishingConfiguration PublishingConfiguration { get; set; } = new PublishingConfiguration();
 
     public static PackageJson? FromJson(in string json)


### PR DESCRIPTION
reason: JsonPropertyName was `publishingConfiguration` which is incorrect wrt official package.json spec.
        This, in turn, might be the cause of npm operations continuous failure.
