### PR TITLE
refactor[ci] (build-cron): comment out cron schedule

### DIFF
--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -1,8 +1,8 @@
 name: build-cron
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  #schedule:
+  #  - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
reason: cost of running cron job is higher than benefit of regular builds
     => disabling for now to save on those precious free GitHub Action minutes
